### PR TITLE
Add empty ConfigMap for constants

### DIFF
--- a/deploy/releases/daily/appsody-app-operator.yaml
+++ b/deploy/releases/daily/appsody-app-operator.yaml
@@ -91,6 +91,17 @@ metadata:
   name: appsody-operator
 ---
 apiVersion: v1
+data:
+  java-microprofile: ""
+  java-spring-boot2: ""
+  nodejs: ""
+  nodejs-express: ""
+  swift: ""
+kind: ConfigMap
+metadata:
+  name: appsody-operator-constants
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: appsody-operator

--- a/deploy/stack_constants.yaml
+++ b/deploy/stack_constants.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  java-microprofile: ""
+  java-spring-boot2: ""
+  nodejs: ""
+  nodejs-express: ""
+  swift: ""
+kind: ConfigMap
+metadata:
+  name: appsody-operator-constants


### PR DESCRIPTION
PR for https://github.com/appsody/appsody-operator/issues/35:
- Added an empty config map YAML to `deploy/stack_constants.yaml` and `deploy/releases/daily/appsody-app-operator.yaml`