### PR TITLE
Install ConfigMaps from image if not already present

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,8 @@ ENV OPERATOR=/usr/local/bin/appsody-operator \
 
 # install operator binary
 COPY build/_output/bin/appsody-operator ${OPERATOR}
-
+COPY deploy/stack_defaults.yaml deploy/
+COPY deploy/stack_constants.yaml deploy/
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 

--- a/deploy/olm-catalog/appsody-operator/0.1.0/appsody-operator.v0.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/appsody-operator/0.1.0/appsody-operator.v0.1.0.clusterserviceversion.yaml
@@ -1,0 +1,152 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"appsody.dev/v1alpha1","kind":"AppsodyApplication","metadata":{"name":"example-appsodyapplication"},"spec":{"applicationImage":"openliberty/open-liberty:microProfile2-ubi-min","stack":"java-microprofile"}}]'
+    capabilities: Basic Install
+  name: appsody-operator.v0.1.0
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Describes application deployment
+      displayName: Appsody Application
+      kind: AppsodyApplication
+      name: appsodyapplications.appsody.dev
+      version: v1alpha1
+  description: Appsody Operator allows installation of applications created with Appsody
+    Stacks
+  displayName: Appsody Operator
+  icon:
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1Ni43MSA1MC43NSI+PGRlZnM+PHN0eWxlPi5he2lzb2xhdGlvbjppc29sYXRlO30uYntvcGFjaXR5OjAuODt9LmIsLmV7bWl4LWJsZW5kLW1vZGU6bXVsdGlwbHk7fS5je2ZpbGw6I2VkOGUwMDt9LmR7ZmlsbDojYzQzMDJmO30uZXtmaWxsOiNhZjFmNjQ7b3BhY2l0eTowLjg1O308L3N0eWxlPjwvZGVmcz48dGl0bGU+QXNzZXQgMjwvdGl0bGU+PGcgY2xhc3M9ImEiPjxnIGNsYXNzPSJiIj48cGF0aCBjbGFzcz0iYyIgZD0iTTI1Ljg4LjI4Yy0yLjUtLjgxLTUuNTguMTQtOC42MywzLjA2TDMuODcsMTYuMTdDLTIuMjIsMjItMSwyOC44MSw2LjYyLDMxLjI3bDE2LjcsNS40MWM3LjYxLDIuNDYsMTIuNi0yLjMyLDExLjA4LTEwLjYyTDMxLjA4LDcuODJjLS43Ni00LjE1LTIuNjktNi43My01LjItNy41NFoiLz48L2c+PGcgY2xhc3M9ImIiPjxwYXRoIGNsYXNzPSJkIiBkPSJNMzcuOTQsMy4xNEExNS43MywxNS43MywwLDAsMCwzMi41NSw0LjZMMTQuNjYsMTIuNzNjLTQuNTcsMi4wNy03LjMxLDUuMjYtNy43Miw5LS4zOSwzLjUyLDEuNDIsNyw1LjA4LDkuNzRsMTUsMTEuMzFhMTIuMjgsMTIuMjgsMCwwLDAsOC4wNiwyLjhjNC43Ny0uMzEsOC4yOS00LjM1LDkuMi0xMC41M2wyLjg0LTE5LjQ0QzQ4LjEyLDksNDUuNTEsNiw0My44Nyw0Ljc1YTguNzksOC43OSwwLDAsMC01LjkzLTEuNjFaIi8+PC9nPjxwYXRoIGNsYXNzPSJlIiBkPSJNMzMuOCw1MC43MWMtMi45My0uMzMtNS41Ny0yLjM5LTcuNDktNS44OEwxNywyNy44Yy0yLjExLTMuODMtMi4zLTcuNDYtLjU0LTEwLjIyczUuMjEtNC4yNiw5Ljc2LTQuMjhsMjAuMjctLjA3YzQuNTYsMCw3LjkxLDEuNSw5LjQyLDQuMjVzMSw2LjM5LTEuNDUsMTAuMjNMNDMuNDksNDQuOGMtMi40NCwzLjgzLTUuNTgsNS45NC04LjgzLDZBNi4xMiw2LjEyLDAsMCwxLDMzLjgsNTAuNzFaIi8+PC9nPjwvc3ZnPg==
+    mediatype: image/svg+xml
+  install:
+    spec:
+      deployments:
+      - name: appsody-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: appsody-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: appsody-operator
+            spec:
+              containers:
+              - command:
+                - appsody-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: appsody-operator
+                image: appsody/application-operator:daily
+                imagePullPolicy: Always
+                name: appsody-operator
+                resources: {}
+              serviceAccountName: appsody-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - appsody-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - appsody.dev
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        - apiGroups:
+          - serving.knative.dev
+          resources:
+          - services
+          verbs:
+          - '*'
+        serviceAccountName: appsody-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - Appsody
+  - Application
+  - Node
+  - Swift
+  - MicroProfile
+  - Spring
+  - Java
+  - Runtime
+  maintainers:
+  - email: dzmitry@ca.ibm.com
+    name: Artur Dzmitryieu
+  - email: navidst@ca.ibm.com
+    name: Navid Shakibapour Tabrizi
+  - email: leocj@ca.ibm.com
+    name: Leo Christy Jesuraj
+  - email: arthurdm@ca.ibm.com
+    name: Arthur De Magalhaes
+  maturity: alpha
+  provider:
+    name: IBM
+  version: 0.1.0

--- a/deploy/olm-catalog/appsody-operator/0.1.0/appsody_v1alpha1_appsodyapplication_crd.yaml
+++ b/deploy/olm-catalog/appsody-operator/0.1.0/appsody_v1alpha1_appsodyapplication_crd.yaml
@@ -1,0 +1,175 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: appsodyapplications.appsody.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.applicationImage
+    description: Absolute name of the deployed image containing registry and tag
+    name: Image
+    type: string
+  - JSONPath: .spec.expose
+    description: Specifies whether deployment is exposed externally via default Route
+    name: Exposed
+    type: boolean
+  - JSONPath: .status.conditions[?(@.type=='Reconciled')].status
+    description: Status of the reconcile condition
+    name: Reconciled
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Reconciled')].reason
+    description: Reason for the failure of reconcile condition
+    name: Reason
+    priority: 1
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Reconciled')].message
+    description: Failure message from reconcile condition
+    name: Message
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of the resource
+    name: Age
+    type: date
+  group: appsody.dev
+  names:
+    kind: AppsodyApplication
+    listKind: AppsodyApplicationList
+    plural: appsodyapplications
+    singular: appsodyapplication
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            applicationImage:
+              description: Image to de
+              type: string
+            architecture:
+              description: Architecture Preferences
+              items:
+                type: string
+              type: array
+            autoscaling:
+              properties:
+                maxReplicas:
+                  format: int32
+                  minimum: 1
+                  type: integer
+                minReplicas:
+                  format: int32
+                  type: integer
+                targetCPUUtilizationPercentage:
+                  format: int32
+                  type: integer
+              type: object
+            createKnativeService:
+              description: Install Knative Service
+              type: boolean
+            env:
+              items:
+                type: object
+              type: array
+            envFrom:
+              items:
+                type: object
+              type: array
+            expose:
+              type: boolean
+            livenessProbe:
+              type: object
+            pullPolicy:
+              description: 'The policy used when pulling the image. One of: Always,
+                Never, and IfNotPresent'
+              type: string
+            pullSecret:
+              description: If using a registry that requires authentication, the name
+                of the secret containing credentials
+              type: string
+            readinessProbe:
+              type: object
+            replicas:
+              description: Number of replicas
+              format: int32
+              type: integer
+            resourceConstraints:
+              type: object
+            service:
+              properties:
+                port:
+                  format: int32
+                  maximum: 65536
+                  minimum: 1
+                  type: integer
+                type:
+                  type: string
+              type: object
+            serviceAccountName:
+              type: string
+            stack:
+              description: Appsody Stack
+              type: string
+            storage:
+              properties:
+                mountPath:
+                  type: string
+                size:
+                  type: string
+                volumeClaimTemplate:
+                  type: object
+              required:
+              - mountPath
+              type: object
+            volumeMounts:
+              items:
+                type: object
+              type: array
+            volumes:
+              items:
+                type: object
+              type: array
+          required:
+          - applicationImage
+          - stack
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true


### PR DESCRIPTION
- Read config map files from deploy folder locally or inside the image
- Apply them to the cluster, if already they exist ignore the error
- Stop operator if it can't find/create maps
- Improve formatting by removing redundant else blocks

Resolves #49 