### PR TITLE
Additional e2e storage testing

### DIFF
--- a/test/e2e/appsody_storage.go
+++ b/test/e2e/appsody_storage.go
@@ -46,6 +46,7 @@ func AppsodyBasicStorageTest(t *testing.T) {
 		MountPath: "/mnt/data",
 	}
 
+	// create resource
 	err = f.Client.Create(goctx.TODO(), exampleAppsody, &framework.CleanupOptions{
 		TestContext:   ctx,
 		Timeout:       time.Second * 5,


### PR DESCRIPTION
**What this PR does / why we need it**:

- Builds have been failing for new e2e features, need to resolve the issues before additions can be added.
- Planning to iteratively add updated storage test, to see if and when the e2e tests are failing.
- Test updates will verify that if storage is disabled after the statefulset has been deployed, it will replace the statefulset with a deployment.