### PR TITLE
Changed e2e test to use node as default stack

### DIFF
--- a/test/e2e/appsody_probe.go
+++ b/test/e2e/appsody_probe.go
@@ -1,0 +1,106 @@
+package e2e
+
+import (
+	goctx "context"
+	"testing"
+	"time"
+
+	appsodyv1beta1 "github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/appsody/appsody-operator/test/util"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	e2eutil "github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// AppsodyProbeTest make sure user defined liveness/readiness probes reach ready state.
+func AppsodyProbeTest(t *testing.T) {
+	ctx, err := util.InitializeContext(t, cleanupTimeout, retryInterval)
+	defer ctx.Cleanup()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		t.Fatalf("Couldn't get namespace: %v", err)
+	}
+
+	t.Logf("Namespace: %s", namespace)
+
+	f := framework.Global
+
+	// create one replica of the operator deployment in current namespace with provided name
+	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "appsody-operator", 1, retryInterval, operatorTimeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	libertyProbe := corev1.Handler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Path: "/",
+			Port: intstr.FromInt(3000),
+		},
+	}
+
+	// run test for readiness probe and then liveness
+	if err = probeTest(t, f, ctx, libertyProbe); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func probeTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, probe corev1.Handler) error {
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		return err
+	}
+	// default appsody test now has to define probes manually, so we will use those and change in the edit test.
+	exampleAppsody := util.MakeBasicAppsodyApplication(t, f, "example-appsody-readiness", namespace, 1)
+
+	err = f.Client.Create(goctx.TODO(), exampleAppsody, &framework.CleanupOptions{
+		TestContext:   ctx,
+		Timeout:       time.Second * 5,
+		RetryInterval: time.Second,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-appsody-readiness", 1, retryInterval, timeout)
+	if err != nil {
+		return err
+	}
+
+	if err = editProbeTest(t, f, ctx, exampleAppsody); err != nil {
+		return err
+	}
+	return nil
+}
+
+func editProbeTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, app *appsodyv1beta1.AppsodyApplication) error {
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		return err
+	}
+
+	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-appsody-readiness", Namespace: namespace}, app)
+	if err != nil {
+		return err
+	}
+
+	// Adjust tests for update SMALL amounts to keep the test fast.
+	app.Spec.LivenessProbe.InitialDelaySeconds = int32(6)
+	app.Spec.ReadinessProbe.InitialDelaySeconds = int32(3)
+	err = f.Client.Update(goctx.TODO(), app)
+	if err != nil {
+		return err
+	}
+
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-appsody-readiness", 1, retryInterval, timeout)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/test/e2e/appsody_test.go
+++ b/test/e2e/appsody_test.go
@@ -23,4 +23,5 @@ func TestAppsodyApplication(t *testing.T) {
 	t.Run("AppsodyPullPolicyTest", AppsodyPullPolicyTest)
 	t.Run("AppsodyBasicTest", AppsodyBasicTest)
 	t.Run("AppsodyStorageTest", AppsodyBasicStorageTest)
+	t.Run("AppsodyProbeTest", AppsodyProbeTest)
 }

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -6,14 +6,22 @@ import (
 
 	appsodyv1beta1 "github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 )
 
 // MakeBasicAppsodyApplication : Create a simple Appsody App with provided number of replicas.
 func MakeBasicAppsodyApplication(t *testing.T, f *framework.Framework, n string, ns string, replicas int32) *appsodyv1beta1.AppsodyApplication {
+	probe := corev1.Handler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Path: "/",
+			Port: intstr.FromInt(3000),
+		},
+	}
 	return &appsodyv1beta1.AppsodyApplication{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AppsodyApplication",
@@ -28,6 +36,22 @@ func MakeBasicAppsodyApplication(t *testing.T, f *framework.Framework, n string,
 			Replicas:         &replicas,
 			Service: &appsodyv1beta1.AppsodyApplicationService{
 				Port: 3000,
+			},
+			ReadinessProbe: &corev1.Probe{
+				Handler:             probe,
+				InitialDelaySeconds: 1, // minor adjustment
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    16,
+			},
+			LivenessProbe: &corev1.Probe{
+				Handler:             probe,
+				InitialDelaySeconds: 4, // minor adjustment
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    6,
 			},
 			Stack: "nodejs-express",
 		},

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -24,12 +24,12 @@ func MakeBasicAppsodyApplication(t *testing.T, f *framework.Framework, n string,
 			Namespace: ns,
 		},
 		Spec: appsodyv1beta1.AppsodyApplicationSpec{
-			ApplicationImage: "openliberty/open-liberty:microProfile2-ubi-min",
+			ApplicationImage: "navidsh/demo-day",
 			Replicas:         &replicas,
 			Service: &appsodyv1beta1.AppsodyApplicationService{
-				Port: 9080,
+				Port: 3000,
 			},
-			Stack: "java-microprofile",
+			Stack: "nodejs-express",
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Updates the default appsody application to use node-express instead of microprofile.
- Drastically speeds up our e2e tests.
- Includes additional test that adjust probe values after deployment, watching that it adjusts accordingly.