### PR TITLE
Fix .travis to not fail for PR builds from a fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ stages:
 
 jobs:
  include:
+  - name: Build docker image
+    stage: build
+    script:
+    - make build-image
   - name: unit test
     stage: unit test
     script:
@@ -34,9 +38,10 @@ jobs:
     script: 
     - make setup-cluster
     - make test-e2e
-  - name: push docker image
-    stage: build and push
+  - name: Build docker image and push 
+    stage: push
     script:
     - make build-image
-    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
     - make push-image
+    if: branch = master AND fork = false AND type != pull_request AND env(DOCKER_USERNAME) IS NOT blank AND env(DOCKER_PASSWORD) IS NOT blank

--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,7 @@ build-image: setup
 	operator-sdk build ${OPERATOR_IMAGE}:${OPERATOR_IMAGE_TAG}
 
 push-image:
-# Push Docker image only if it is building on a master branch that is not a pull request build
-ifeq "${TRAVIS_BRANCH}" "master"
-ifndef TRAVIS_PULL_REQUEST
 	docker push ${OPERATOR_IMAGE}:${OPERATOR_IMAGE_TAG}
-endif
-endif
 
 gofmt:
 	@gofmt -s -l -w $(SRC_FILES)


### PR DESCRIPTION
**What this PR does / why we need it**:
- Simplified `.travis` and separated out the `build` from the `push` stage
- Simplified `Makefile`

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged, then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #99
