### PR TITLE
Cleanup configmap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ jobs:
     stage: build
     script:
     - make build-image
-  - name: unit test
+  - name: Run unit tests
     stage: unit test
     script:
     - make unit-test
-  - name: e2e test
+  - name: Run end-to-end tests
     stage: e2e test
     script: 
     - make setup-cluster

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ unit-test: ## Run unit tests
 	go test -v -mod=vendor -tags=unit github.com/appsody/appsody-operator/pkg/...
 
 test-e2e: setup ## Run end-to-end tests
-	operator-sdk test local github.com/appsody/appsody-operator/test/e2e --verbose --debug --up-local --namespace default
+	operator-sdk test local github.com/appsody/appsody-operator/test/e2e --verbose --debug --up-local --namespace ${WATCH_NAMESPACE}
 
 generate: setup ## Invoke `k8s` and `openapi` generators
 	operator-sdk generate k8s

--- a/Makefile
+++ b/Makefile
@@ -2,45 +2,55 @@ OPERATOR_SDK_RELEASE_VERSION ?= v0.8.1
 OPERATOR_IMAGE ?= appsody/application-operator
 OPERATOR_IMAGE_TAG ?= daily
 
+WATCH_NAMESPACE ?= default
+
 GIT_COMMIT  ?= $(shell git rev-parse --short HEAD)
 
 # Get source files, ignore vendor directory
 SRC_FILES := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
-.PHONY: build test deploy
+.DEFAULT_GOAL := help
 
-setup:
+.PHONY: help setup setup-cluster tidy build unit-test test-e2e generate build-image push-image gofmt golint clean install deploy
+
+help: 
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+setup: ## Ensure Operator SDK is installed
 	./scripts/install-operator-sdk.sh ${OPERATOR_SDK_RELEASE_VERSION}
 
-setup-cluster:
+setup-cluster: ## Install `oc` and starts OpenShift on Docker
 	./scripts/setup-cluster.sh
 
-tidy:
+tidy: ## Clean up Go modules by adding missing and removing unused modules
 	go mod tidy
 
-build:
+build: ## Compile the operator
 	go install ./cmd/manager
 
-unit-test:
-	go test -v -mod=vendor -tags=unit github.com/appsody/appsody-operator/pkg/controller/appsodyapplication
+unit-test: ## Run unit tests
+	go test -v -mod=vendor -tags=unit github.com/appsody/appsody-operator/pkg/...
 
-test-e2e: setup
+test-e2e: ## Run end-to-end tests
+	setup
 	operator-sdk test local github.com/appsody/appsody-operator/test/e2e --verbose --debug --up-local --namespace default
 
-generate: setup
+generate: ## Invoke `k8s` and `openapi` generators
+	setup
 	operator-sdk generate k8s
 	operator-sdk generate openapi
 
-build-image: setup
+build-image: ## Build operator Docker image and tag with "${OPERATOR_IMAGE}:${OPERATOR_IMAGE_TAG}"
+	setup
 	operator-sdk build ${OPERATOR_IMAGE}:${OPERATOR_IMAGE_TAG}
 
-push-image:
+push-image: ## Push operator image
 	docker push ${OPERATOR_IMAGE}:${OPERATOR_IMAGE_TAG}
 
-gofmt:
+gofmt: ## Format the Go code with `gofmt`
 	@gofmt -s -l -w $(SRC_FILES)
 
-golint:
+golint: ## Run linter on operator code
 	for file in $(SRC_FILES); do \
 		golint $${file}; \
 		if [ -n "$$(golint $${file})" ]; then \
@@ -48,13 +58,13 @@ golint:
 		fi; \
 	done
 
-clean:
+clean: ## Clean binary artifacts
 	rm -rf build/_output
 
-install:
+install: ## Installs operator CRD in the daily directory
 	kubectl apply -f deploy/releases/daily/appsody-app-crd.yaml
 	
-deploy:
+deploy: ## Deploys operator across cluster and watches ${WATCH_NAMESPACE} namespace. If ${WATCH_NAMESPACE} is not specified, it defaults to `default` namespace
 ifneq "${OPERATOR_IMAGE}:${OPERATOR_IMAGE_TAG}" "appsody/application-operator:daily"
 	sed -i.bak -e 's!image: appsody/application-operator:daily!image: ${OPERATOR_IMAGE}:${OPERATOR_IMAGE_TAG}!' deploy/releases/daily/appsody-app-operator.yaml
 endif

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ SRC_FILES := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 .PHONY: help setup setup-cluster tidy build unit-test test-e2e generate build-image push-image gofmt golint clean install deploy
 
 help: 
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 setup: ## Ensure Operator SDK is installed
 	./scripts/install-operator-sdk.sh ${OPERATOR_SDK_RELEASE_VERSION}
@@ -31,17 +31,14 @@ build: ## Compile the operator
 unit-test: ## Run unit tests
 	go test -v -mod=vendor -tags=unit github.com/appsody/appsody-operator/pkg/...
 
-test-e2e: ## Run end-to-end tests
-	setup
+test-e2e: setup ## Run end-to-end tests
 	operator-sdk test local github.com/appsody/appsody-operator/test/e2e --verbose --debug --up-local --namespace default
 
-generate: ## Invoke `k8s` and `openapi` generators
-	setup
+generate: setup ## Invoke `k8s` and `openapi` generators
 	operator-sdk generate k8s
 	operator-sdk generate openapi
 
-build-image: ## Build operator Docker image and tag with "${OPERATOR_IMAGE}:${OPERATOR_IMAGE_TAG}"
-	setup
+build-image: setup ## Build operator Docker image and tag with "${OPERATOR_IMAGE}:${OPERATOR_IMAGE_TAG}"
 	operator-sdk build ${OPERATOR_IMAGE}:${OPERATOR_IMAGE_TAG}
 
 push-image: ## Push operator image

--- a/deploy/releases/0.1.0/readme.md
+++ b/deploy/releases/0.1.0/readme.md
@@ -29,8 +29,8 @@ _Limitation: Operator cannot be installed to watch multiple namespaces_
     - To watch all namespaces in the cluster, set `WATCH_NAMESPACE='""'`
 
     ```console
-    OPERATOR_NAMESPACE=`<SPECIFY_OPERATOR_NAMESPACE_HERE>`
-    WATCH_NAMESPACE=`<SPECIFY_WATCH_NAMESPACE_HERE>`
+    OPERATOR_NAMESPACE=<SPECIFY_OPERATOR_NAMESPACE_HERE>
+    WATCH_NAMESPACE=<SPECIFY_WATCH_NAMESPACE_HERE>
     ```
 
     2.2. _Optional_: Install cluster-level role based access. This step can be skipped if the operator is only watching its own namespace:

--- a/deploy/releases/daily/readme.md
+++ b/deploy/releases/daily/readme.md
@@ -29,12 +29,13 @@ _Limitation: Operator cannot be installed to watch multiple namespaces_
     - To watch all namespaces in the cluster, set `WATCH_NAMESPACE='""'`
 
     ```console
-    OPERATOR_NAMESPACE=`<SPECIFY_OPERATOR_NAMESPACE_HERE>`
-    WATCH_NAMESPACE=`<SPECIFY_WATCH_NAMESPACE_HERE>`
+    OPERATOR_NAMESPACE=<SPECIFY_OPERATOR_NAMESPACE_HERE>
+    WATCH_NAMESPACE=<SPECIFY_WATCH_NAMESPACE_HERE>
     ```
 
     2.2. _Optional_: Install cluster-level role based access. This step can be skipped if the operator is only watching its own namespace:
-    ```
+  
+    ```console
     curl -L https://raw.githubusercontent.com/appsody/appsody-operator/master/deploy/releases/daily/appsody-app-cluster-rbac.yaml \
       | sed -e "s/APPSODY_OPERATOR_NAMESPACE/${OPERATOR_NAMESPACE}/" \
       | kubectl apply -f -

--- a/deploy/stack_defaults.yaml
+++ b/deploy/stack_defaults.yaml
@@ -1,15 +1,24 @@
 # Appsody Operator would create this ConfigMap automatically during installation, so you don't have to apply this manually.
 apiVersion: v1
 data:
-  java-microprofile: ""
-  java-spring-boot2: ""
-  nodejs: ""
-  nodejs-express: ""
-  swift: ""
+  java-microprofile: |-
+    service:
+      port: 9080
+  java-spring-boot2: |-
+    service:
+      port: 8080
+  nodejs: |-
+    service:
+      port: 3000
+  nodejs-express: |-
+    service:
+      port: 3000
+  swift: |-
+    service:
+      port: 8080
   generic: |-
     service:
       port: 3000
-      type: ClusterIP
 kind: ConfigMap
 metadata:
   name: appsody-operator-defaults

--- a/deploy/stack_defaults.yaml
+++ b/deploy/stack_defaults.yaml
@@ -1,21 +1,11 @@
 # Appsody Operator would create this ConfigMap automatically during installation, so you don't have to apply this manually.
 apiVersion: v1
 data:
-  java-microprofile: |-
-    service:
-      port: 9080
-  java-spring-boot2: |-
-    service:
-      port: 8080
-  nodejs: |-
-    service:
-      port: 3000
-  nodejs-express: |-
-    service:
-      port: 3000
-  swift: |-
-    service:
-      port: 8080
+  java-microprofile: ""
+  java-spring-boot2: ""
+  nodejs: ""
+  nodejs-express: ""
+  swift: ""
   generic: |-
     service:
       port: 3000

--- a/deploy/stack_defaults.yaml
+++ b/deploy/stack_defaults.yaml
@@ -1,88 +1,11 @@
 # Appsody Operator would create this ConfigMap automatically during installation, so you don't have to apply this manually.
 apiVersion: v1
 data:
-  java-microprofile: |-
-    expose: false
-    livenessProbe:
-      failureThreshold: 3
-      httpGet:
-        path: /health
-        port: 9080
-      initialDelaySeconds: 60
-      periodSeconds: 5
-    readinessProbe:
-      failureThreshold: 12
-      httpGet:
-        path: /health
-        port: 9080
-      initialDelaySeconds: 30
-      periodSeconds: 5
-    resourceConstraints:
-      requests:
-        memory: 512Mi
-    service:
-      port: 9080
-      type: ClusterIP
-  java-spring-boot2: |-
-    expose: false
-    livenessProbe:
-      failureThreshold: 3
-      httpGet:
-        path: /actuator/liveness
-        port: 8080
-      initialDelaySeconds: 60
-      periodSeconds: 5
-    readinessProbe:
-      failureThreshold: 12
-      httpGet:
-        path: /actuator/health
-        port: 8080
-      initialDelaySeconds: 30
-      periodSeconds: 5
-    resourceConstraints:
-      requests:
-        memory: 512Mi
-    service:
-      port: 8080
-      type: ClusterIP
-  nodejs: |-
-    expose: false
-    resourceConstraints:
-      requests:
-        memory: 256Mi
-    service:
-      port: 3000
-      type: ClusterIP
-  nodejs-express: |-
-    expose: false
-    livenessProbe:
-      failureThreshold: 3
-      httpGet:
-        path: /live
-        port: 3000
-      initialDelaySeconds: 60
-      periodSeconds: 5
-    readinessProbe:
-      failureThreshold: 12
-      httpGet:
-        path: /ready
-        port: 3000
-      initialDelaySeconds: 30
-      periodSeconds: 5
-    resourceConstraints:
-      requests:
-        memory: 256Mi
-    service:
-      port: 3000
-      type: ClusterIP
-  swift: |-
-    expose: false
-    resourceConstraints:
-      requests:
-        memory: 256Mi
-    service:
-      port: 8080
-      type: ClusterIP
+  java-microprofile: ""
+  java-spring-boot2: ""
+  nodejs: ""
+  nodejs-express: ""
+  swift: ""
   generic: |-
     service:
       port: 3000

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -324,13 +324,12 @@ func InitAndValidate(cr *appsodyv1beta1.AppsodyApplication, defaults appsodyv1be
 	}
 
 	if cr.Spec.Service == nil {
-		if defaults.Service == nil {
-			st := corev1.ServiceTypeClusterIP
-			cr.Spec.Service.Type = &st
-			cr.Spec.Service.Port = 8080
-		} else {
-			cr.Spec.Service = defaults.Service
-		}
+		cr.Spec.Service = defaults.Service
+	}
+
+	// This is to handle when there is no service in the CR nor defaults
+	if cr.Spec.Service == nil {
+		cr.Spec.Service = &appsodyv1beta1.AppsodyApplicationService{}
 	}
 
 	if cr.Spec.Service.Type == nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -324,16 +324,18 @@ func InitAndValidate(cr *appsodyv1beta1.AppsodyApplication, defaults appsodyv1be
 	}
 
 	if cr.Spec.Service == nil {
-		cr.Spec.Service = defaults.Service
+		if defaults.Service == nil {
+			st := corev1.ServiceTypeClusterIP
+			cr.Spec.Service.Type = &st
+			cr.Spec.Service.Port = 8080
+		} else {
+			cr.Spec.Service = defaults.Service
+		}
 	}
 
 	if cr.Spec.Service.Type == nil {
-		if defaults.Service.Type != nil {
-			cr.Spec.Service.Type = defaults.Service.Type
-		} else {
-			st := corev1.ServiceTypeClusterIP
-			cr.Spec.Service.Type = &st
-		}
+		st := corev1.ServiceTypeClusterIP
+		cr.Spec.Service.Type = &st
 	}
 	if cr.Spec.Service.Port == 0 {
 		if defaults.Service.Port != 0 {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -233,7 +233,6 @@ func TestCustomizeKnativeService(t *testing.T) {
 	ksvc, appsody := &servingv1alpha1.Service{}, createAppsodyApp(name, namespace, spec)
 
 	CustomizeKnativeService(ksvc, appsody)
-	ksvcContainerName := ksvc.Spec.Template.Spec.Containers[0].Name
 	ksvcNumPorts := len(ksvc.Spec.Template.Spec.Containers[0].Ports)
 	ksvcSAN := ksvc.Spec.Template.Spec.ServiceAccountName
 
@@ -256,7 +255,6 @@ func TestCustomizeKnativeService(t *testing.T) {
 	appsody = createAppsodyApp(name, namespace, spec)
 	CustomizeKnativeService(ksvc, appsody)
 	testCKS := []Test{
-		{"ksvc Container Name", "user-container", ksvcContainerName},
 		{"ksvc container ports", 1, ksvcNumPorts},
 		{"ksvc ServiceAccountName is nil", name, ksvcSAN},
 		{"ksvc ServiceAccountName not nil", *appsody.Spec.ServiceAccountName, ksvc.Spec.Template.Spec.ServiceAccountName},


### PR DESCRIPTION
**What this PR does / why we need it**:
- Removed default values in the `appsody-operator-defaults` `ConfigMap`
- Fixed `nil` panic in `pkg/utils/utils.go` if `service.Type` is not defined in the CR nor defaults `ConfigMap`
- Fixed typos in `deploy/releases/*/readme.md`
- Added help text into Makefile to list all make targets as well as what each target does as follows:
    ```
    ⇒  make
    build-image                    Build operator Docker image and tag with "${OPERATOR_IMAGE}:${OPERATOR_IMAGE_TAG}"
    build                          Compile the operator
    clean                          Clean binary artifacts
    ...
    ```
- Updated Makefile to run all unit tests rather than a subset
- Fixed a unit test failuire that was checking for `ksvc`'s container name
