### PR TITLE
Add support for watching multiple namespaces

### DIFF
--- a/deploy/releases/daily/appsody-app-operator.yaml
+++ b/deploy/releases/daily/appsody-app-operator.yaml
@@ -108,7 +108,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              value: APPSODY_WATCH_NAMESPACE
+              value: appsody-app
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/releases/daily/appsody-app-operator.yaml
+++ b/deploy/releases/daily/appsody-app-operator.yaml
@@ -108,7 +108,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              value: appsody-app
+              value: APPSODY_WATCH_NAMESPACE
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/pkg/controller/appsodyapplication/appsodyapplication_controller_test.go
+++ b/pkg/controller/appsodyapplication/appsodyapplication_controller_test.go
@@ -58,6 +58,7 @@ type Test struct {
 func TestAppsodyController(t *testing.T) {
 	// Set the logger to development mode for verbose logs
 	logf.SetLogger(logf.ZapLogger(true))
+	os.Setenv("WATCH_NAMESPACE", namespace)
 
 	spec := appsodyv1beta1.AppsodyApplicationSpec{Stack: stack}
 	appsody := createAppsodyApp(name, namespace, spec)
@@ -259,8 +260,9 @@ func TestAppsodyController(t *testing.T) {
 }
 
 func TestConfigMapDefaults(t *testing.T) {
-	os.Setenv("WATCH_NAMESPACE", namespace)
+	// Set the logger to development mode for verbose logs
 	logf.SetLogger(logf.ZapLogger(true))
+	os.Setenv("WATCH_NAMESPACE", namespace)
 
 	spec := appsodyv1beta1.AppsodyApplicationSpec{Stack: stack, Service: service}
 	appsody := createAppsodyApp(name, namespace, spec)
@@ -301,8 +303,9 @@ func TestConfigMapDefaults(t *testing.T) {
 }
 
 func TestConfigMapConstants(t *testing.T) {
-	os.Setenv("WATCH_NAMESPACE", namespace)
+	// Set the logger to development mode for verbose logs
 	logf.SetLogger(logf.ZapLogger(true))
+	os.Setenv("WATCH_NAMESPACE", namespace)
 
 	spec := appsodyv1beta1.AppsodyApplicationSpec{Stack: stack}
 	appsody := createAppsodyApp(name, namespace, spec)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	appsodyv1beta1 "github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1"
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	routev1 "github.com/openshift/api/route/v1"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -491,4 +492,20 @@ func SetCondition(condition appsodyv1beta1.StatusCondition, status *appsodyv1bet
 	}
 
 	status.Conditions = append(status.Conditions, condition)
+}
+
+// GetWatchNamespaces returns a slice of namespaces the operator should watch based on WATCH_NAMESPSCE value
+// WATCH_NAMESPSCE value could be empty for watching the whole cluster or a comma-separated list of namespaces
+func GetWatchNamespaces() ([]string, error) {
+	watchNamespace, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		return nil, err
+	}
+
+	var watchNamespaces []string
+	for _, ns := range strings.Split(watchNamespace, ",") {
+		watchNamespaces = append(watchNamespaces, strings.TrimSpace(ns))
+	}
+
+	return watchNamespaces, nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -337,7 +337,7 @@ func InitAndValidate(cr *appsodyv1beta1.AppsodyApplication, defaults appsodyv1be
 		cr.Spec.Service.Type = &st
 	}
 	if cr.Spec.Service.Port == 0 {
-		if defaults.Service.Port != 0 {
+		if defaults.Service != nil && defaults.Service.Port != 0 {
 			cr.Spec.Service.Port = defaults.Service.Port
 		} else {
 			cr.Spec.Service.Port = 8080


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add support for watching multiple namespaces by watching on all namespaces and filtering the events (via predicates) to the desired namespaces.
- Added new Make targets for easy operator installation and uninstallation.
- Added unit tests

