### PR TITLE
Allows the user to add new labels and overwrite the old ones 

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -116,6 +116,7 @@ metadata:
 spec:
   stack: java-microprofile
   applicationImage: quay.io/my-repo/my-app:1.0
+```
 
 ### Environment variables
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -102,6 +102,21 @@ Users can also specify `serviceAccountName` when they want to create a service a
 
 If applications require specific permissions but still want the operator to create a `ServiceAccount`, users can still manually create a role binding to bind a role to the service account created by the operator. To learn more about Role-based access control (RBAC), see Kubernetes [documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
 
+### Labels
+
+By default, the operator adds the following labels into all resources created for an `AppsodyApplication` CR: `app.kubernetes.io/name`, `app.kubernetes.io/managed-by`, `app.appsody.dev/stack`. You can set new labels in addition to the pre-existing ones or overwrite them, excluding the `app.kubernetes.io/name` label. To set labels, specify them in your CR as key/value pairs.
+
+```yaml
+apiVersion: appsody.dev/v1beta1
+kind: AppsodyApplication
+metadata:
+  name: my-appsody-app
+  labels:
+    my-label-key: my-label-value
+spec:
+  stack: java-microprofile
+  applicationImage: quay.io/my-repo/my-app:1.0
+
 ### Environment variables
 
 You can set environment variables for your application container. To set environment variables, specify `env` and/or `envFrom` fields in your CR. The environment variables can come directly from key/value pairs, `ConfigMap`s or `Secret`s.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,9 +24,9 @@ func GetLabels(cr *appsodyv1beta1.AppsodyApplication) map[string]string {
 		"app.appsody.dev/stack":        cr.Spec.Stack,
 	}
 
-	for i, j := range cr.Labels {
-		if i != "app.kubernetes.io/name" {
-			labels[i] = j
+	for key, value := range cr.Labels {
+		if key != "app.kubernetes.io/name" {
+			labels[key] = value
 		}
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -23,6 +23,13 @@ func GetLabels(cr *appsodyv1beta1.AppsodyApplication) map[string]string {
 		"app.kubernetes.io/managed-by": "appsody-operator",
 		"app.appsody.dev/stack":        cr.Spec.Stack,
 	}
+
+	for i, j := range cr.Labels {
+		if i != "app.kubernetes.io/name" {
+			labels[i] = j
+		}
+	}
+
 	return labels
 }
 


### PR DESCRIPTION

**What this PR does / why we need it**:

- Allows the user to add and overwrite labels
- Excludes the app.kubernetes.io/name field

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged, then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #84 