### PR TITLE
Update user-guide to be consistent

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -10,12 +10,10 @@ The Appsody Operator can be installed to:
 
 - watch its own namespace
 - watch another namespace
-- warch multiple namespaces
+- watch multiple namespaces
 - watch all namespaces in the cluster
 
-Appropriate cluster role and binding are required to watch another namespace, watch multiple namespaces or to watch all namespaces.
-
-_Limitation: Operator cannot be installed to watch multiple namespaces_
+Appropriate cluster roles and bindings are required to watch another namespace, watch multiple namespaces or to watch all namespaces.
 
 ## Overview
 


### PR DESCRIPTION
Remove conflicting information about watching multiple namespaces from the user guide.

**What this PR does / why we need it**:

Makes `user-guide.md` consistent regarding support for watching multiple namespaces.