### PR TITLE
Add name to port in service

### DIFF
--- a/pkg/controller/appsodyapplication/appsodyapplication_controller_test.go
+++ b/pkg/controller/appsodyapplication/appsodyapplication_controller_test.go
@@ -3,6 +3,7 @@ package appsodyapplication
 import (
 	"context"
 	"os"
+	"strconv"
 	"testing"
 
 	appsodyv1beta1 "github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1"
@@ -198,7 +199,7 @@ func TestAppsodyController(t *testing.T) {
 	}
 
 	// Check updated values in Route
-	routeTests := []Test{{"target port", intstr.FromInt(int(service.Port)), route.Spec.Port.TargetPort}}
+	routeTests := []Test{{"target port", intstr.FromString(strconv.Itoa(int(service.Port)) + "-tcp"), route.Spec.Port.TargetPort}}
 	verifyTests("route", routeTests, t)
 
 	// Disable Route/Expose and enable Autoscaling

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	prometheusv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -110,7 +111,8 @@ func CustomizeRoute(route *routev1.Route, cr *appsodyv1beta1.AppsodyApplication)
 	if route.Spec.Port == nil {
 		route.Spec.Port = &routev1.RoutePort{}
 	}
-	route.Spec.Port.TargetPort = intstr.FromInt(int(cr.Spec.Service.Port))
+	route.Spec.Port.TargetPort = intstr.FromString(strconv.Itoa(int(cr.Spec.Service.Port)) + "-tcp")
+
 }
 
 // ErrorIsNoMatchesForKind ...
@@ -127,6 +129,7 @@ func CustomizeService(svc *corev1.Service, cr *appsodyv1beta1.AppsodyApplication
 	}
 	svc.Spec.Ports[0].Port = cr.Spec.Service.Port
 	svc.Spec.Ports[0].TargetPort = intstr.FromInt(int(cr.Spec.Service.Port))
+	svc.Spec.Ports[0].Name = strconv.Itoa(int(cr.Spec.Service.Port)) + "-tcp"
 	svc.Spec.Type = *cr.Spec.Service.Type
 	svc.Spec.Selector = map[string]string{
 		"app.kubernetes.io/name": cr.Name,
@@ -144,6 +147,7 @@ func CustomizePodSpec(pts *corev1.PodTemplateSpec, cr *appsodyv1beta1.AppsodyApp
 		pts.Spec.Containers[0].Ports = append(pts.Spec.Containers[0].Ports, corev1.ContainerPort{})
 	}
 	pts.Spec.Containers[0].Ports[0].ContainerPort = cr.Spec.Service.Port
+	pts.Spec.Containers[0].Ports[0].Name = strconv.Itoa(int(cr.Spec.Service.Port)) + "-tcp"
 	pts.Spec.Containers[0].Image = cr.Spec.ApplicationImage
 	pts.Spec.Containers[0].Resources = *cr.Spec.ResourceConstraints
 	pts.Spec.Containers[0].ReadinessProbe = cr.Spec.ReadinessProbe
@@ -566,8 +570,7 @@ func CustomizeServiceMonitor(sm *prometheusv1.ServiceMonitor, cr *appsodyv1beta1
 	if len(sm.Spec.Endpoints) == 0 {
 		sm.Spec.Endpoints = append(sm.Spec.Endpoints, prometheusv1.Endpoint{})
 	}
-	targetPort := intstr.FromInt(int(cr.Spec.Service.Port))
-	sm.Spec.Endpoints[0].TargetPort = &targetPort
+	sm.Spec.Endpoints[0].Port = strconv.Itoa(int(cr.Spec.Service.Port)) + "-tcp"
 	if len(cr.Spec.Monitoring.Labels) > 0 {
 		for k, v := range cr.Spec.Monitoring.Labels {
 			sm.Labels[k] = v
@@ -596,6 +599,12 @@ func CustomizeServiceMonitor(sm *prometheusv1.ServiceMonitor, cr *appsodyv1beta1
 
 		if cr.Spec.Monitoring.Endpoints[0].Params != nil {
 			sm.Spec.Endpoints[0].Params = cr.Spec.Monitoring.Endpoints[0].Params
+		}
+		if cr.Spec.Monitoring.Endpoints[0].ScrapeTimeout != "" {
+			sm.Spec.Endpoints[0].ScrapeTimeout = cr.Spec.Monitoring.Endpoints[0].ScrapeTimeout
+		}
+		if cr.Spec.Monitoring.Endpoints[0].BearerTokenFile != "" {
+			sm.Spec.Endpoints[0].BearerTokenFile = cr.Spec.Monitoring.Endpoints[0].BearerTokenFile
 		}
 	}
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"os"
 	"reflect"
+	"strconv"
 	"testing"
 
 	appsodyv1beta1 "github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1"
@@ -82,7 +83,7 @@ func TestCustomizeRoute(t *testing.T) {
 		{"Route target kind", "Service", route.Spec.To.Kind},
 		{"Route target name", name, route.Spec.To.Name},
 		{"Route target weight", int32(100), *route.Spec.To.Weight},
-		{"Route service target port", intstr.FromInt(int(appsody.Spec.Service.Port)), route.Spec.Port.TargetPort},
+		{"Route service target port", intstr.FromString(strconv.Itoa(int(appsody.Spec.Service.Port)) + "-tcp"), route.Spec.Port.TargetPort},
 	}
 
 	verifyTests(testCR, t)


### PR DESCRIPTION
Added port name in format '9080-tcp' to service, and use it as reference for Route and ServiceMonitor