### PR TITLE
Fix dead link to additional kAppNav integration info in user-guide.md

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -79,7 +79,7 @@ Each `AppsodyApplication` CR must specify `applicationImage` parameter. Specifyi
 | `storage.volumeClaimTemplate` | A YAML object representing a [volumeClaimTemplate](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#components) component of a `StatefulSet`. |
 | `monitoring.labels` | Labels to set on [ServiceMonitor](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
 | `monitoring.endpoints` | A YAML snippet representing an array of [Endpoint](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint) component from ServiceMonitor. |
-| `createAppDefinition`   | A boolean to toggle the automatic configuration of `AppsodyApplication`'s Kubernetes resources to allow creation of an application definition by [kAppNav](https://kappnav.io/). The default value is `true`. See [Application Navigator](#kubernetes-application-navigator-(kappnav)-support) for more information. |
+| `createAppDefinition`   | A boolean to toggle the automatic configuration of `AppsodyApplication`'s Kubernetes resources to allow creation of an application definition by [kAppNav](https://kappnav.io/). The default value is `true`. See [Application Navigator](#kubernetes-application-navigator-kappnav-support) for more information. |
 
 ### Basic usage
 


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Removed parenthesis from subsection of the link to additional kAppNav information from user-guide.md
- The link worked in VS Code with or without the parenthesis around kappnav but in Github it only links to that section without.
