### PR TITLE
Unit Test for UpdateAppDefinition

### DIFF
--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -579,27 +579,21 @@ func TestUpdateAppDefinition(t *testing.T) {
 
 	spec := appsodyv1beta1.AppsodyApplicationSpec{Service: service, Version: "v1alpha"}
 	app := createAppsodyApp(name, namespace, spec)
-	// Check that app definition enabled by default
-	enabled := true
-	appDefinitionTests := []Test{
-		{"kAppNav enabled", enabled, *app.Spec.CreateAppDefinition},
-	}
-	verifyTests(appDefinitionTests, t)
 
-	enabled = false
-	// Toggle app definition off
+	enabled := false
+	// Toggle app definition off [disabled]
 	app.Spec.CreateAppDefinition = &enabled
 	labels, annotations := createAppDefinitionTags(app)
 	UpdateAppDefinition(labels, annotations, app)
 
-	appDefinitionTests = []Test{
+	appDefinitionTests := []Test{
 		{"Label unset", 0, len(labels)},
 		{"Annotation unset", 0, len(annotations)},
 	}
 
 	verifyTests(appDefinitionTests, t)
 
-	// Toggle back on
+	// Toggle back on [active]
 	enabled = true
 	completeLabel, completeAnnotation := createAppDefinitionTags(app)
 	UpdateAppDefinition(labels, annotations, app)
@@ -614,15 +608,18 @@ func TestUpdateAppDefinition(t *testing.T) {
 	}
 	verifyTests(appDefinitionTests, t)
 
-	// Verify labels are deleted properly now that they exist
-	enabled = false
+	app.Spec.CreateAppDefinition = nil
+	// Verify labels are still set when CreateApp is undefined [default]
 	UpdateAppDefinition(labels, annotations, app)
 
 	appDefinitionTests = []Test{
-		{"Label unset", 0, len(labels)},
-		{"Annotation unset", 0, len(annotations)},
+		{"Label set", labels["kappnav.app.auto-create"], completeLabel["kappnav.app.auto-create"]},
+		{"Annotation name set", annotations["kappnav.app.auto-create.name"], completeAnnotation["kappnav.app.auto-create.name"]},
+		{"Annotation kinds set", annotations["kappnav.app.auto-create.kinds"], completeAnnotation["kappnav.app.auto-create.kinds"]},
+		{"Annotation label set", annotations["kappnav.app.auto-create.label"], completeAnnotation["kappnav.app.auto-create.label"]},
+		{"Annotation labels-values", annotations["kappnav.app.auto-create.labels-values"], completeAnnotation["kappnav.app.auto-create.labels-values"]},
+		{"Annotation version set", annotations["kappnav.app.auto-create.version"], completeAnnotation["kappnav.app.auto-create.version"]},
 	}
-
 	verifyTests(appDefinitionTests, t)
 
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -580,8 +580,8 @@ func TestUpdateAppDefinition(t *testing.T) {
 	spec := appsodyv1beta1.AppsodyApplicationSpec{Service: service, Version: "v1alpha"}
 	app := createAppsodyApp(name, namespace, spec)
 
-	enabled := false
 	// Toggle app definition off [disabled]
+	enabled := false
 	app.Spec.CreateAppDefinition = &enabled
 	labels, annotations := createAppDefinitionTags(app)
 	UpdateAppDefinition(labels, annotations, app)
@@ -595,30 +595,30 @@ func TestUpdateAppDefinition(t *testing.T) {
 
 	// Toggle back on [active]
 	enabled = true
-	completeLabel, completeAnnotation := createAppDefinitionTags(app)
+	completeLabels, completeAnnotations := createAppDefinitionTags(app)
 	UpdateAppDefinition(labels, annotations, app)
 
 	appDefinitionTests = []Test{
-		{"Label set", labels["kappnav.app.auto-create"], completeLabel["kappnav.app.auto-create"]},
-		{"Annotation name set", annotations["kappnav.app.auto-create.name"], completeAnnotation["kappnav.app.auto-create.name"]},
-		{"Annotation kinds set", annotations["kappnav.app.auto-create.kinds"], completeAnnotation["kappnav.app.auto-create.kinds"]},
-		{"Annotation label set", annotations["kappnav.app.auto-create.label"], completeAnnotation["kappnav.app.auto-create.label"]},
-		{"Annotation labels-values", annotations["kappnav.app.auto-create.labels-values"], completeAnnotation["kappnav.app.auto-create.labels-values"]},
-		{"Annotation version set", annotations["kappnav.app.auto-create.version"], completeAnnotation["kappnav.app.auto-create.version"]},
+		{"Label set", labels["kappnav.app.auto-create"], completeLabels["kappnav.app.auto-create"]},
+		{"Annotation name set", annotations["kappnav.app.auto-create.name"], completeAnnotations["kappnav.app.auto-create.name"]},
+		{"Annotation kinds set", annotations["kappnav.app.auto-create.kinds"], completeAnnotations["kappnav.app.auto-create.kinds"]},
+		{"Annotation label set", annotations["kappnav.app.auto-create.label"], completeAnnotations["kappnav.app.auto-create.label"]},
+		{"Annotation labels-values", annotations["kappnav.app.auto-create.labels-values"], completeAnnotations["kappnav.app.auto-create.labels-values"]},
+		{"Annotation version set", annotations["kappnav.app.auto-create.version"], completeAnnotations["kappnav.app.auto-create.version"]},
 	}
 	verifyTests(appDefinitionTests, t)
 
-	app.Spec.CreateAppDefinition = nil
 	// Verify labels are still set when CreateApp is undefined [default]
+	app.Spec.CreateAppDefinition = nil
 	UpdateAppDefinition(labels, annotations, app)
 
 	appDefinitionTests = []Test{
-		{"Label set", labels["kappnav.app.auto-create"], completeLabel["kappnav.app.auto-create"]},
-		{"Annotation name set", annotations["kappnav.app.auto-create.name"], completeAnnotation["kappnav.app.auto-create.name"]},
-		{"Annotation kinds set", annotations["kappnav.app.auto-create.kinds"], completeAnnotation["kappnav.app.auto-create.kinds"]},
-		{"Annotation label set", annotations["kappnav.app.auto-create.label"], completeAnnotation["kappnav.app.auto-create.label"]},
-		{"Annotation labels-values", annotations["kappnav.app.auto-create.labels-values"], completeAnnotation["kappnav.app.auto-create.labels-values"]},
-		{"Annotation version set", annotations["kappnav.app.auto-create.version"], completeAnnotation["kappnav.app.auto-create.version"]},
+		{"Label set", labels["kappnav.app.auto-create"], completeLabels["kappnav.app.auto-create"]},
+		{"Annotation name set", annotations["kappnav.app.auto-create.name"], completeAnnotations["kappnav.app.auto-create.name"]},
+		{"Annotation kinds set", annotations["kappnav.app.auto-create.kinds"], completeAnnotations["kappnav.app.auto-create.kinds"]},
+		{"Annotation label set", annotations["kappnav.app.auto-create.label"], completeAnnotations["kappnav.app.auto-create.label"]},
+		{"Annotation labels-values", annotations["kappnav.app.auto-create.labels-values"], completeAnnotations["kappnav.app.auto-create.labels-values"]},
+		{"Annotation version set", annotations["kappnav.app.auto-create.version"], completeAnnotations["kappnav.app.auto-create.version"]},
 	}
 	verifyTests(appDefinitionTests, t)
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -574,6 +574,19 @@ func TestGetWatchNamespaces(t *testing.T) {
 	verifyTests(configMapConstTests, t)
 }
 
+func TestUpdateAppDefinition(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	spec := appsodyv1beta1.AppsodyApplicationSpec{Service: service}
+	appsody := createAppsodyApp(name, namespace, spec)
+	// Check that app definition enabled by default
+	enabled := true
+	appDefinitionTests = []Test{
+		{"kAppNav enabled", &enabled, appsody.Spec.CreateAppDefinition},
+	}
+
+}
+
 // Helper Functions
 func createAppsodyApp(n, ns string, spec appsodyv1beta1.AppsodyApplicationSpec) *appsodyv1beta1.AppsodyApplication {
 	app := &appsodyv1beta1.AppsodyApplication{


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Adds unit test coverage for the kAppNav label/annotation updating method in utils.go
- Addresses lack of testing for the kAppNav integration
- Will want to investigate e2e testing as well down the line

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
No
