### PR TITLE
Change label for stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Changed the label corresponding to the `Stack` information from `app.appsody.dev/stack` to `stack.appsody.dev/id`. ([#168](https://github.com/appsody/appsody-operator/issues/168))
+- Changed the label corresponding to the Appsody Stack information from `app.appsody.dev/stack` to `stack.appsody.dev/id`. ([#168](https://github.com/appsody/appsody-operator/issues/168))
 
 ## [0.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.
 
 The initial release of the Appsody Operator 🎉🥳
 
-[Unreleased]: https://github.com/appsody/appsody-operator/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/appsody/appsody-operator/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/appsody/appsody-operator/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/appsody/appsody-operator/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/appsody/appsody-operator/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Changed the label corresponding to the Appsody Stack information from `app.appsody.dev/stack` to `stack.appsody.dev/id`. ([#168](https://github.com/appsody/appsody-operator/issues/168))
+- Changed the label corresponding to the Appsody Stack information from `app.appsody.dev/stack` to `stack.appsody.dev/id`. ([#169](https://github.com/appsody/appsody-operator/issues/169))
 
 ## [0.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.1]
+
+### Added
+
+- Added documentation on how to do canary testing with the standard `Route` resource. ([#143](https://github.com/appsody/appsody-operator/issues/143))
+
+### Changed
+
+- Changed the label corresponding to the `Stack` information from `app.appsody.dev/stack` to `stack.appsody.dev/id`. ([#168](https://github.com/appsody/appsody-operator/issues/168))
+
 ## [0.2.0]
 
 ### Added

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -107,7 +107,7 @@ If applications require specific permissions but still want the operator to crea
 
 ### Labels
 
-By default, the operator adds the following labels into all resources created for an `AppsodyApplication` CR: `app.kubernetes.io/name`, `app.kubernetes.io/managed-by`, `app.appsody.dev/stack` and `app.kubernetes.io/version` (only when `version` is defined). You can set new labels in addition to the pre-existing ones or overwrite them, excluding the `app.kubernetes.io/name` label. To set labels, specify them in your CR as key/value pairs.
+By default, the operator adds the following labels into all resources created for an `AppsodyApplication` CR: `app.kubernetes.io/name`, `app.kubernetes.io/managed-by`, `app.kubernetes.io/version` (when `version` is defined) and `stack.appsody.dev/id` (when `stack` is defined). You can set new labels in addition to the pre-existing ones or overwrite them, excluding the `app.kubernetes.io/name` label. To set labels, specify them in your CR as key/value pairs.
 
 ```yaml
 apiVersion: appsody.dev/v1beta1

--- a/pkg/apis/appsody/v1beta1/appsodyapplication_types.go
+++ b/pkg/apis/appsody/v1beta1/appsodyapplication_types.go
@@ -522,7 +522,7 @@ func (cr *AppsodyApplication) GetLabels() map[string]string {
 	}
 
 	if cr.Spec.Stack != "" {
-		labels["app.appsody.dev/stack"] = cr.Spec.Stack
+		labels["stack.appsody.dev/id"] = cr.Spec.Stack
 	}
 
 	if cr.Spec.Version != "" {


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Change the label corresponding to the Appsody Stack information from `app.appsody.dev/stack` to `stack.appsody.dev/id`

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [x] User guide
- [x] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #165
