### PR TITLE
Update knative test to correctly identify when knative is not installed

### DIFF
--- a/test/e2e/appsody_knative.go
+++ b/test/e2e/appsody_knative.go
@@ -9,8 +9,6 @@ import (
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	e2eutil "github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // AppsodyKnativeTest : Create application with knative service enabled to verify feature
@@ -58,16 +56,15 @@ func AppsodyKnativeTest(t *testing.T) {
 }
 
 func isKnativeInstalled(t *testing.T, f *framework.Framework) bool {
-	deployments := &corev1.PodList{}
-	options := &dynclient.ListOptions{
-		Namespace: "knative-serving",
-	}
-	err := f.Client.List(goctx.TODO(), deployments, options)
+	ns := &corev1.NamespaceList{}
+	err := f.Client.List(goctx.TODO(), ns)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return false
-		}
 		t.Fatalf("Error occurred while trying to find knative-serving %v", err)
 	}
-	return true
+	for _, val := range ns.Items {
+		if val.Name == "knative-serving" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Method that checked whether or not knative was installed in the cluster that e2e tests were being run in was not functioning as expected.
- Updated it to correctly check for knative namespace and skip the knative test if not present.
- This allows for easier local testing through minishift or environment that does not have knative

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
No
