### PR TITLE
Appsody Operator must-gather

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ stages:
   - name: unit test
   - name: e2e test
   - name: push
+  - name: build must gather
+  - name: push must gather
 
 jobs:
  include:
@@ -43,4 +45,15 @@ jobs:
     - make build-image
     - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
     - make push-image
+    if: branch = master AND fork = false AND type != pull_request AND env(DOCKER_USERNAME) IS NOT blank AND env(DOCKER_PASSWORD) IS NOT blank
+  - name: Build must gather image
+    stage: build must gather
+    script:
+      - make build-must-gather
+  - name: Build must gather image and push
+    stage: push must gather
+    script:
+    - make build-must-gather
+    - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+    - make push-must-gather
     if: branch = master AND fork = false AND type != pull_request AND env(DOCKER_USERNAME) IS NOT blank AND env(DOCKER_PASSWORD) IS NOT blank

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ stages:
   - name: unit test
   - name: e2e test
   - name: push
-  - name: build must gather
-  - name: push must gather
+  - name: build and push must gather
 
 jobs:
  include:
@@ -46,12 +45,8 @@ jobs:
     - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
     - make push-image
     if: branch = master AND fork = false AND type != pull_request AND env(DOCKER_USERNAME) IS NOT blank AND env(DOCKER_PASSWORD) IS NOT blank
-  - name: Build must gather image
-    stage: build must gather
-    script:
-      - make build-must-gather
   - name: Build must gather image and push
-    stage: push must gather
+    stage: build and push must gather
     script:
     - make build-must-gather
     - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Added must-gather scripts for troubleshooting. ([#148](https://github.com/appsody/appsody-operator/issues/148))
+- Added must-gather scripts for troubleshooting. ([#209](https://github.com/appsody/appsody-operator/pull/209))
 
 ## [0.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added must-gather scripts for troubleshooting. ([#148](https://github.com/appsody/appsody-operator/issues/148))
+
 ## [0.3.0]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 OPERATOR_SDK_RELEASE_VERSION ?= v0.12.0
 OPERATOR_IMAGE ?= appsody/application-operator
 OPERATOR_IMAGE_TAG ?= daily
+OPERATOR_MUST_GATHER_TAG ?= daily-must-gather
 
 WATCH_NAMESPACE ?= default
 OPERATOR_NAMESPACE ?= ${WATCH_NAMESPACE}
@@ -45,6 +46,12 @@ build-image: setup ## Build operator Docker image and tag with "${OPERATOR_IMAGE
 
 push-image: ## Push operator image
 	docker push ${OPERATOR_IMAGE}:${OPERATOR_IMAGE_TAG}
+
+build-must-gather: setup ## Build operator Docker image and tag with "${OPERATOR_IMAGE}:${OPERATOR_MUST_GATHER_TAG}"
+	operator-sdk build ${OPERATOR_IMAGE}:${OPERATOR_MUST_GATHER_TAG}
+
+push-must-gather: ## Push operator must gather image
+	docker push ${OPERATOR_IMAGE}:${OPERATOR_MUST_GATHER_TAG}
 
 gofmt: ## Format the Go code with `gofmt`
 	@gofmt -s -l -w $(SRC_FILES)

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -74,7 +74,7 @@ If the operator is running fine, check the status of the `AppsodyApplication` Cu
 $ oc adm must-gather --image=docker.io/appsody/application-operator:daily-must-gather
 ```
 
-Note: `must-gather` flag is a new feature added to oc v4.x. If you are using an older version of oc, you can get a new version of the CLI from here. You can use oc v4.x against 3.11 cluster.
+Note: `must-gather` flag is a new feature added to OpenShift client CLI v4.x. If you are using an older version of OpenShift client CLI, you can get a new version of the CLI from [here](https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.2/). You can use OpenShift client CLI v4.x against 3.11 cluster.
 
 The command above will create a local directory with a dump of the Appsody Operator collection state. Note that this command will only get data related to the Appsody Operator Collection of the OpenShift cluster. 
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -63,3 +63,19 @@ If the operator is running fine, check the status of the `AppsodyApplication` Cu
   ```console
   $ oc describe appsodyapplication my-appsody-app
   ```
+
+## Appsody Operator must-gather
+
+`Appsody Operator must-gather` is a tool built on top of OpenShift must-gather that expands its capabilities to gather information about the Appsody Operator.
+
+### Usage
+
+```console
+$ oc adm must-gather --image=docker.io/appsody/application-operator:daily-must-gather
+```
+
+Note: `must-gather` flag is a new feature added to oc v4.x. If you are using an older version of oc, you can get a new version of the CLI from here. You can use oc v4.x against 3.11 cluster.
+
+The command above will create a local directory with a dump of the Appsody Operator collection state. Note that this command will only get data related to the Appsody Operator Collection of the OpenShift cluster. 
+
+In order to get data about other parts of the cluster (not specific to Appsody Operator) you should run just `oc adm must-gather` (without passing a custom image). Run `oc adm must-gather -h` to see more options.

--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,0 +1,9 @@
+FROM quay.io/openshift/origin-must-gather:4.2
+
+# Save original gather script
+RUN mv /usr/bin/gather /usr/bin/gather_original
+
+# Copy all scripts to /usr/bin
+COPY gather_appsodyoperator/* /usr/bin/
+
+ENTRYPOINT /usr/bin/gather

--- a/must-gather/LICENSE
+++ b/must-gather/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -1,0 +1,1 @@
+# appsodyoperator-must-gather

--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -1,11 +1,1 @@
 # Appsody Operator must-gather
-
-Appsody Operator must-gather is a tool built on top of OpenShift must-gather that expands its capabilities to gather information about the Appsody Operator.
-
-Usage
-oc adm must-gather --image=docker.io/appsody/application-operator:daily-must-gather
-Note: must-gather flag is a new feature added to oc v4.x. If you are using an older version of oc, you can get a new version of the CLI from here. You can use oc v4.x against 3.11 cluster.
-
-The command above will create a local directory with a dump of the Appsody Operator collection state. Note that this command will only get data related to the Appsody Operator Collection of the OpenShift cluster. 
-
-In order to get data about other parts of the cluster (not specific to Appsody Operator) you should run just oc adm must-gather (without passing a custom image). Run oc adm must-gather -h to see more options.

--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -1,1 +1,11 @@
-# appsodyoperator-must-gather
+# Appsody Operator must-gather
+
+Appsody Operator must-gather is a tool built on top of OpenShift must-gather that expands its capabilities to gather information about the Appsody Operator.
+
+Usage
+oc adm must-gather --image=docker.io/appsody/application-operator:daily-must-gather
+Note: must-gather flag is a new feature added to oc v4.x. If you are using an older version of oc, you can get a new version of the CLI from here. You can use oc v4.x against 3.11 cluster.
+
+The command above will create a local directory with a dump of the Appsody Operator collection state. Note that this command will only get data related to the Appsody Operator Collection of the OpenShift cluster. 
+
+In order to get data about other parts of the cluster (not specific to Appsody Operator) you should run just oc adm must-gather (without passing a custom image). Run oc adm must-gather -h to see more options.

--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -1,1 +1,3 @@
 # Appsody Operator must-gather
+
+See the [troubleshooting guide](troubleshooting.md) for information on how to use the Appsody Operator must-gather.

--- a/must-gather/gather_appsodyoperator/gather
+++ b/must-gather/gather_appsodyoperator/gather
@@ -15,17 +15,10 @@ resources=($resources)
 
 for i in ${!names[@]}
 do
-    mkdir -p ${LOGS_DIR}/${namespaces[i]}/${SUB_DIR}/${resources[i]}
-    ${BIN} get ${resources[i]} ${names[i]} -n ${namespaces[i]} -o=yaml > ${LOGS_DIR}/${namespaces[i]}/${SUB_DIR}/${resources[i]}/get.yaml
-    kubectl describe ${resources[i]} ${names[i]} -n ${namespaces[i]} > ${LOGS_DIR}/${namespaces[i]}/${SUB_DIR}/${resources[i]}/describe.log
+	mkdir -p ${LOGS_DIR}/${namespaces[i]}/${SUB_DIR}/${resources[i]}
+	${BIN} get ${resources[i]} ${names[i]} -n ${namespaces[i]} -o=yaml > ${LOGS_DIR}/${namespaces[i]}/${SUB_DIR}/${resources[i]}/get.yaml
+	${BIN} describe ${resources[i]} ${names[i]} -n ${namespaces[i]} > ${LOGS_DIR}/${namespaces[i]}/${SUB_DIR}/${resources[i]}/describe.log
 done 
-
-# Run the collection of resources using must-gather
-# for resource in ${resources[@]}; do
-#     echo
-#     echo "Dumping resource ${resource}..."
-#     ${MUST_GATHER} inspect --dest-dir must-gather ${resource}
-# done
 
 /usr/bin/gather_pods
 /usr/bin/gather_appsody

--- a/must-gather/gather_appsodyoperator/gather
+++ b/must-gather/gather_appsodyoperator/gather
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+LOGS_DIR="/must-gather"
+BIN=oc
+SUB_DIR="resources"
+
+# Resource List containing all the resources created by appsody
+names=$(oc get all -l app.kubernetes.io/managed-by=appsody-operator --all-namespaces -o jsonpath="{.items[*].metadata.name}")
+namespaces=$(oc get all -l app.kubernetes.io/managed-by=appsody-operator --all-namespaces -o jsonpath="{.items[*].metadata.namespace}")
+resources=$(oc get all -l app.kubernetes.io/managed-by=appsody-operator --all-namespaces -o jsonpath="{.items[*].kind}")
+
+names=($names)
+namespaces=($namespaces)
+resources=($resources)
+
+for i in ${!names[@]}
+do
+    mkdir -p ${LOGS_DIR}/${namespaces[i]}/${SUB_DIR}/${resources[i]}
+    ${BIN} get ${resources[i]} ${names[i]} -n ${namespaces[i]} -o=yaml > ${LOGS_DIR}/${namespaces[i]}/${SUB_DIR}/${resources[i]}/get.yaml
+    kubectl describe ${resources[i]} ${names[i]} -n ${namespaces[i]} > ${LOGS_DIR}/${namespaces[i]}/${SUB_DIR}/${resources[i]}/describe.log
+done 
+
+# Run the collection of resources using must-gather
+# for resource in ${resources[@]}; do
+#     echo
+#     echo "Dumping resource ${resource}..."
+#     ${MUST_GATHER} inspect --dest-dir must-gather ${resource}
+# done
+
+/usr/bin/gather_pods
+/usr/bin/gather_appsody
+/usr/bin/gather_knative
+/usr/bin/gather_appsodyoperator
+
+exit 0

--- a/must-gather/gather_appsodyoperator/gather_appsody
+++ b/must-gather/gather_appsodyoperator/gather_appsody
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Run this script to collect debug information
+
+set -Euox pipefail
+
+COMPONENT="appsody.dev"
+BIN=oc
+LOGS_DIR="/must-gather"
+
+# Describe and Get all api resources of component across cluster
+
+APIRESOURCES=$(${BIN} get crds -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ${COMPONENT})
+
+for APIRESOURCE in ${APIRESOURCES[@]}
+do
+	NAMESPACES=$(${BIN} get ${APIRESOURCE} --all-namespaces=true -o jsonpath='{range .items[*]}{@.metadata.namespace}{"\n"}{end}' | uniq)
+	for NAMESPACE in ${NAMESPACES[@]}
+	do
+		mkdir -p ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}
+		${BIN} describe ${APIRESOURCE} -n ${NAMESPACE} > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/describe.log
+		${BIN} get ${APIRESOURCE} -n ${NAMESPACE} -o=yaml > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/get.yaml
+	done
+done

--- a/must-gather/gather_appsodyoperator/gather_appsodyoperator
+++ b/must-gather/gather_appsodyoperator/gather_appsodyoperator
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Run this script to collect de-bug information about the appsody operator pod
+
+set -Euox pipefail
+
+BIN=oc
+LOGS_DIR="/must-gather"
+SUB_DIR="appsodyoperatorpods"
+
+# Get the pod name(s) and namespace(s) that the appsody-operator(s) are running in, across all namespaces
+PODS=$(${BIN} get pods --all-namespaces -o jsonpath="{.items[?(@.metadata.labels.name=='appsody-operator')].metadata.name}")
+NAMESPACES=$(${BIN} get pods --all-namespaces -o jsonpath="{.items[?(@.metadata.labels.name=='appsody-operator')].metadata.namespace}")
+
+PODS=($PODS)
+NAMESPACES=($NAMESPACES)
+
+# Get, describe, and log the pods of the operator(s)
+for POD in ${!PODS[@]}
+do
+    mkdir -p ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}
+    ${BIN} get pod ${PODS[$POD]} -n ${NAMESPACES[$POD]} -o=yaml > ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}/get.yaml
+    ${BIN} describe pod ${PODS[$POD]} -n ${NAMESPACES[$POD]} > ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}/describe.log
+    LOGS=$(${BIN} logs ${PODS[${POD}]} -n ${NAMESPACES[$POD]} 2>&1)
+    echo ${LOGS} > ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}/logs.log
+done

--- a/must-gather/gather_appsodyoperator/gather_appsodyoperator
+++ b/must-gather/gather_appsodyoperator/gather_appsodyoperator
@@ -18,9 +18,9 @@ NAMESPACES=($NAMESPACES)
 # Get, describe, and log the pods of the operator(s)
 for POD in ${!PODS[@]}
 do
-    mkdir -p ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}
-    ${BIN} get pod ${PODS[$POD]} -n ${NAMESPACES[$POD]} -o=yaml > ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}/get.yaml
-    ${BIN} describe pod ${PODS[$POD]} -n ${NAMESPACES[$POD]} > ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}/describe.log
-    LOGS=$(${BIN} logs ${PODS[${POD}]} -n ${NAMESPACES[$POD]} 2>&1)
-    echo ${LOGS} > ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}/logs.log
+	mkdir -p ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}
+	${BIN} get pod ${PODS[$POD]} -n ${NAMESPACES[$POD]} -o=yaml > ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}/get.yaml
+	${BIN} describe pod ${PODS[$POD]} -n ${NAMESPACES[$POD]} > ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}/describe.log
+	LOGS=$(${BIN} logs ${PODS[${POD}]} -n ${NAMESPACES[$POD]} 2>&1)
+	echo ${LOGS} > ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}/operatorlogs.log
 done

--- a/must-gather/gather_appsodyoperator/gather_knative
+++ b/must-gather/gather_appsodyoperator/gather_knative
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Run this script to collect debug information
+
+set -Euox pipefail
+
+COMPONENT="knative.dev"
+BIN=oc
+LOGS_DIR="/must-gather"
+
+# Describe and Get all api resources of component across cluster
+
+APIRESOURCES=$(${BIN} get crds -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ${COMPONENT})
+
+for APIRESOURCE in ${APIRESOURCES[@]}
+do
+	NAMESPACES=$(${BIN} get ${APIRESOURCE} --all-namespaces=true -o jsonpath='{range .items[*]}{@.metadata.namespace}{"\n"}{end}' | uniq)
+	for NAMESPACE in ${NAMESPACES[@]}
+	do
+		mkdir -p ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}
+		${BIN} describe ${APIRESOURCE} -n ${NAMESPACE} > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/describe.log
+		${BIN} get ${APIRESOURCE} -n ${NAMESPACE} -o=yaml > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/get.yaml
+	done
+done
+
+
+# Collect pod logs, describe & get additional resources
+
+NAMESPACES=(knative-eventing knative-serving knative-sources)
+APIRESOURCES=(configmaps pods routes roles rolebindings serviceaccounts services)
+
+for NAMESPACE in ${NAMESPACES[@]}
+do
+	PODS=$(${BIN} get pods -n ${NAMESPACE} -o jsonpath="{.items[*].metadata.name}")
+	mkdir -p ${LOGS_DIR}/${NAMESPACE}/pods
+	for POD in ${PODS[@]}
+	do
+		${BIN} logs --all-containers=true -n ${NAMESPACE} ${POD} > ${LOGS_DIR}/${NAMESPACE}/pods/${POD}.log
+	done
+
+	for APIRESOURCE in ${APIRESOURCES[@]}
+	do
+		mkdir -p ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}
+		${BIN} describe ${APIRESOURCE} -n ${NAMESPACE} > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/describe.log
+		${BIN} get ${APIRESOURCE} -n ${NAMESPACE} -o=yaml > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/get.yaml
+	done
+done
+
+
+# Collect clusterroles and clusterrolebindings
+
+KEY="knative"
+NAMESPACE="kube-system"
+
+APIRESOURCE="clusterroles"
+NAMES=$(${BIN} get ${APIRESOURCE} -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ${KEY})
+for NAME in ${NAMES[@]}
+do
+	mkdir -p ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}
+	${BIN} describe ${APIRESOURCE} ${NAME} > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/${NAME}-describe.log
+	${BIN} get ${APIRESOURCE} ${NAME} -o=yaml > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/${NAME}.yaml
+done
+
+APIRESOURCE="clusterrolebindings"
+NAMES=$(${BIN} get ${APIRESOURCE} -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ${KEY})
+for NAME in ${NAMES[@]}
+do
+	mkdir -p ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}
+	${BIN} describe ${APIRESOURCE} ${NAME} > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/${NAME}-describe.log
+	${BIN} get ${APIRESOURCE} ${NAME} -o=yaml > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/${NAME}.yaml
+done

--- a/must-gather/gather_appsodyoperator/gather_pods
+++ b/must-gather/gather_appsodyoperator/gather_pods
@@ -17,8 +17,9 @@ PODS=($PODS)
 NAMESPACES=($NAMESPACES)
 
 # Describe and get all pods that are not ready
-for i in ${!PODS[@]}; do
-    mkdir -p ${LOGS_DIR}/${NAMESPACES[$i]}/${SUB_DIR}/${PODS[$i]}
-    ${BIN} describe pod ${PODS[$i]} -n ${NAMESPACES[$i]} > ${LOGS_DIR}/${NAMESPACES[$i]}/${SUB_DIR}/${PODS[$i]}/describe.log
-    ${BIN} get pod ${PODS[$i]} -n ${NAMESPACES[$i]} -o=yaml > ${LOGS_DIR}/${NAMESPACES[$i]}/${SUB_DIR}/${PODS[$i]}/get.yaml
+for POD in ${!PODS[@]}
+do
+	mkdir -p ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}
+	${BIN} describe pod ${PODS[$POD]} -n ${NAMESPACES[$POD]} > ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}/describe.log
+	${BIN} get pod ${PODS[$POD]} -n ${NAMESPACES[$POD]} -o=yaml > ${LOGS_DIR}/${NAMESPACES[$POD]}/${SUB_DIR}/${PODS[$POD]}/get.yaml
 done

--- a/must-gather/gather_appsodyoperator/gather_pods
+++ b/must-gather/gather_appsodyoperator/gather_pods
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Run this script to collect debug information regarding pods that are not ready
+
+set -Euox pipefail
+
+BIN=oc
+LOGS_DIR="/must-gather"
+SUB_DIR="pods"
+
+# Get pods that are not ready and their namespaces
+PODS=$(${BIN} get pods --all-namespaces -o jsonpath="{.items[?(@.status.containerStatuses[*].ready==false)].metadata.name}")
+NAMESPACES=$(${BIN} get pods --all-namespaces -o jsonpath="{.items[?(@.status.containerStatuses[*].ready==false)].metadata.namespace}")
+
+# Puts pods and corresponding names into arrays
+PODS=($PODS)
+NAMESPACES=($NAMESPACES)
+
+# Describe and get all pods that are not ready
+for i in ${!PODS[@]}; do
+    mkdir -p ${LOGS_DIR}/${NAMESPACES[$i]}/${SUB_DIR}/${PODS[$i]}
+    ${BIN} describe pod ${PODS[$i]} -n ${NAMESPACES[$i]} > ${LOGS_DIR}/${NAMESPACES[$i]}/${SUB_DIR}/${PODS[$i]}/describe.log
+    ${BIN} get pod ${PODS[$i]} -n ${NAMESPACES[$i]} -o=yaml > ${LOGS_DIR}/${NAMESPACES[$i]}/${SUB_DIR}/${PODS[$i]}/get.yaml
+done


### PR DESCRIPTION
**What this PR does / why we need it?**:

- `Appsody Operator must-gather` is a tool built on top of OpenShift must-gather that expands its capabilities to gather information about the Appsody Operator.
- Creates a local directory with a dump of relevant troubleshooting information
- Includes information about the pods that are not in the ready state, appsody operator pod(s), knative, appsody application, and the resources that are managed by the operator

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [x] User guide
- [x] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #148
