### PR TITLE
Remove operator push stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ stages:
   - name: build
   - name: unit test
   - name: e2e test
-  - name: push
   - name: build and push must gather
 
 jobs:
@@ -38,13 +37,6 @@ jobs:
     stage: e2e test
     script:
     - make test-e2e
-  - name: Build docker image and push
-    stage: push
-    script:
-    - make build-image
-    - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    - make push-image
-    if: branch = master AND fork = false AND type != pull_request AND env(DOCKER_USERNAME) IS NOT blank AND env(DOCKER_PASSWORD) IS NOT blank
   - name: Build must gather image and push
     stage: build and push must gather
     script:


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Removes the docker build/push stage from travis to avoid overwriting the manifest list that will now be pushed from GHE

