### PR TITLE
Add certificate secret reference property

### DIFF
--- a/deploy/crds/appsody.dev_appsodyapplications_crd.yaml
+++ b/deploy/crds/appsody.dev_appsodyapplications_crd.yaml
@@ -1976,6 +1976,8 @@ spec:
                         type: string
                       type: array
                   type: object
+                certificateSecretRef:
+                  type: string
                 host:
                   type: string
                 insecureEdgeTerminationPolicy:
@@ -2129,6 +2131,8 @@ spec:
                         type: string
                       type: array
                   type: object
+                certificateSecretRef:
+                  type: string
                 consumes:
                   items:
                     description: ServiceBindingConsumes represents a service to be
@@ -2207,6 +2211,9 @@ spec:
                   required:
                   - category
                   type: object
+                targetPort:
+                  format: int32
+                  type: integer
                 type:
                   description: Service Type string describes ingress methods for a
                     service

--- a/pkg/apis/appsody/v1beta1/appsodyapplication_types.go
+++ b/pkg/apis/appsody/v1beta1/appsodyapplication_types.go
@@ -67,7 +67,7 @@ type AppsodyApplicationService struct {
 
 	// +kubebuilder:validation:Maximum=65536
 	// +kubebuilder:validation:Minimum=1
-	Port int32 `json:"port,omitempty"`
+	Port       int32  `json:"port,omitempty"`
 	TargetPort *int32 `json:"targetPort,omitempty"`
 
 	Annotations map[string]string `json:"annotations,omitempty"`
@@ -75,7 +75,8 @@ type AppsodyApplicationService struct {
 	Consumes []ServiceBindingConsumes `json:"consumes,omitempty"`
 	Provides *ServiceBindingProvides  `json:"provides,omitempty"`
 	// +k8s:openapi-gen=true
-	Certificate *Certificate `json:"certificate,omitempty"`
+	Certificate          *Certificate `json:"certificate,omitempty"`
+	CertificateSecretRef *string      `json:"certificateSecretRef,omitempty"`
 }
 
 // ServiceBindingProvides represents information about
@@ -118,6 +119,7 @@ type AppsodyRoute struct {
 	Termination                   *routev1.TLSTerminationType                `json:"termination,omitempty"`
 	InsecureEdgeTerminationPolicy *routev1.InsecureEdgeTerminationPolicyType `json:"insecureEdgeTerminationPolicy,omitempty"`
 	Certificate                   *Certificate                               `json:"certificate,omitempty"`
+	CertificateSecretRef          *string                                    `json:"certificateSecretRef,omitempty"`
 	Host                          string                                     `json:"host,omitempty"`
 	Path                          string                                     `json:"path,omitempty"`
 }
@@ -405,7 +407,6 @@ func (s *AppsodyApplicationService) GetTargetPort() *int32 {
 	return s.TargetPort
 }
 
-
 // GetType returns service type
 func (s *AppsodyApplicationService) GetType() *corev1.ServiceType {
 	return s.Type
@@ -425,6 +426,11 @@ func (s *AppsodyApplicationService) GetCertificate() common.Certificate {
 		return nil
 	}
 	return s.Certificate
+}
+
+// GetCertificateSecretRef returns services certificate configuration
+func (s *AppsodyApplicationService) GetCertificateSecretRef() *string {
+	return s.CertificateSecretRef
 }
 
 // GetCategory returns category of a service provider configuration
@@ -510,6 +516,11 @@ func (r *AppsodyRoute) GetCertificate() common.Certificate {
 		return nil
 	}
 	return r.Certificate
+}
+
+// GetCertificateSecretRef returns services certificate configuration
+func (r *AppsodyRoute) GetCertificateSecretRef() *string {
+	return r.CertificateSecretRef
 }
 
 // GetTermination returns terminatation of the route's TLS
@@ -791,7 +802,6 @@ func (cr *AppsodyApplication) applyConstants(defaults AppsodyApplicationSpec, co
 			cr.Spec.Service.TargetPort = constants.Service.TargetPort
 		}
 	}
-
 
 	if constants.Autoscaling != nil {
 		cr.Spec.Autoscaling = constants.Autoscaling

--- a/pkg/apis/appsody/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/appsody/v1beta1/zz_generated.deepcopy.go
@@ -166,6 +166,11 @@ func (in *AppsodyApplicationService) DeepCopyInto(out *AppsodyApplicationService
 		*out = new(Certificate)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CertificateSecretRef != nil {
+		in, out := &in.CertificateSecretRef, &out.CertificateSecretRef
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -393,6 +398,11 @@ func (in *AppsodyRoute) DeepCopyInto(out *AppsodyRoute) {
 		in, out := &in.Certificate, &out.Certificate
 		*out = new(Certificate)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.CertificateSecretRef != nil {
+		in, out := &in.CertificateSecretRef, &out.CertificateSecretRef
+		*out = new(string)
+		**out = **in
 	}
 	return
 }

--- a/pkg/apis/appsody/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/appsody/v1beta1/zz_generated.openapi.go
@@ -11,15 +11,15 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplication":            schema_pkg_apis_appsody_v1beta1_AppsodyApplication(ref),
-		"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationAutoScaling": schema_pkg_apis_appsody_v1beta1_AppsodyApplicationAutoScaling(ref),
-		"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationService":     schema_pkg_apis_appsody_v1beta1_AppsodyApplicationService(ref),
-		"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationSpec":        schema_pkg_apis_appsody_v1beta1_AppsodyApplicationSpec(ref),
-		"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationStatus":      schema_pkg_apis_appsody_v1beta1_AppsodyApplicationStatus(ref),
-		"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyRoute":                  schema_pkg_apis_appsody_v1beta1_AppsodyRoute(ref),
-		"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.ServiceBindingConsumes":        schema_pkg_apis_appsody_v1beta1_ServiceBindingConsumes(ref),
-		"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.ServiceBindingProvides":        schema_pkg_apis_appsody_v1beta1_ServiceBindingProvides(ref),
-		"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.StatusCondition":               schema_pkg_apis_appsody_v1beta1_StatusCondition(ref),
+		"./pkg/apis/appsody/v1beta1.AppsodyApplication":            schema_pkg_apis_appsody_v1beta1_AppsodyApplication(ref),
+		"./pkg/apis/appsody/v1beta1.AppsodyApplicationAutoScaling": schema_pkg_apis_appsody_v1beta1_AppsodyApplicationAutoScaling(ref),
+		"./pkg/apis/appsody/v1beta1.AppsodyApplicationService":     schema_pkg_apis_appsody_v1beta1_AppsodyApplicationService(ref),
+		"./pkg/apis/appsody/v1beta1.AppsodyApplicationSpec":        schema_pkg_apis_appsody_v1beta1_AppsodyApplicationSpec(ref),
+		"./pkg/apis/appsody/v1beta1.AppsodyApplicationStatus":      schema_pkg_apis_appsody_v1beta1_AppsodyApplicationStatus(ref),
+		"./pkg/apis/appsody/v1beta1.AppsodyRoute":                  schema_pkg_apis_appsody_v1beta1_AppsodyRoute(ref),
+		"./pkg/apis/appsody/v1beta1.ServiceBindingConsumes":        schema_pkg_apis_appsody_v1beta1_ServiceBindingConsumes(ref),
+		"./pkg/apis/appsody/v1beta1.ServiceBindingProvides":        schema_pkg_apis_appsody_v1beta1_ServiceBindingProvides(ref),
+		"./pkg/apis/appsody/v1beta1.StatusCondition":               schema_pkg_apis_appsody_v1beta1_StatusCondition(ref),
 	}
 }
 
@@ -51,19 +51,19 @@ func schema_pkg_apis_appsody_v1beta1_AppsodyApplication(ref common.ReferenceCall
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationSpec"),
+							Ref: ref("./pkg/apis/appsody/v1beta1.AppsodyApplicationSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationStatus"),
+							Ref: ref("./pkg/apis/appsody/v1beta1.AppsodyApplicationStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationSpec", "github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./pkg/apis/appsody/v1beta1.AppsodyApplicationSpec", "./pkg/apis/appsody/v1beta1.AppsodyApplicationStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -117,7 +117,7 @@ func schema_pkg_apis_appsody_v1beta1_AppsodyApplicationService(ref common.Refere
 							Format: "int32",
 						},
 					},
-					"TargetPort": {
+					"targetPort": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"integer"},
 							Format: "int32",
@@ -148,7 +148,7 @@ func schema_pkg_apis_appsody_v1beta1_AppsodyApplicationService(ref common.Refere
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.ServiceBindingConsumes"),
+										Ref: ref("./pkg/apis/appsody/v1beta1.ServiceBindingConsumes"),
 									},
 								},
 							},
@@ -156,20 +156,25 @@ func schema_pkg_apis_appsody_v1beta1_AppsodyApplicationService(ref common.Refere
 					},
 					"provides": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.ServiceBindingProvides"),
+							Ref: ref("./pkg/apis/appsody/v1beta1.ServiceBindingProvides"),
 						},
 					},
 					"certificate": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.Certificate"),
+							Ref: ref("./pkg/apis/appsody/v1beta1.Certificate"),
+						},
+					},
+					"certificateSecretRef": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},
-				Required: []string{"TargetPort"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.Certificate", "github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.ServiceBindingConsumes", "github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.ServiceBindingProvides"},
+			"./pkg/apis/appsody/v1beta1.Certificate", "./pkg/apis/appsody/v1beta1.ServiceBindingConsumes", "./pkg/apis/appsody/v1beta1.ServiceBindingProvides"},
 	}
 }
 
@@ -200,7 +205,7 @@ func schema_pkg_apis_appsody_v1beta1_AppsodyApplicationSpec(ref common.Reference
 					},
 					"autoscaling": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationAutoScaling"),
+							Ref: ref("./pkg/apis/appsody/v1beta1.AppsodyApplicationAutoScaling"),
 						},
 					},
 					"pullPolicy": {
@@ -267,7 +272,7 @@ func schema_pkg_apis_appsody_v1beta1_AppsodyApplicationSpec(ref common.Reference
 					},
 					"service": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationService"),
+							Ref: ref("./pkg/apis/appsody/v1beta1.AppsodyApplicationService"),
 						},
 					},
 					"expose": {
@@ -337,7 +342,7 @@ func schema_pkg_apis_appsody_v1beta1_AppsodyApplicationSpec(ref common.Reference
 					},
 					"storage": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationStorage"),
+							Ref: ref("./pkg/apis/appsody/v1beta1.AppsodyApplicationStorage"),
 						},
 					},
 					"createKnativeService": {
@@ -354,7 +359,7 @@ func schema_pkg_apis_appsody_v1beta1_AppsodyApplicationSpec(ref common.Reference
 					},
 					"monitoring": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationMonitoring"),
+							Ref: ref("./pkg/apis/appsody/v1beta1.AppsodyApplicationMonitoring"),
 						},
 					},
 					"createAppDefinition": {
@@ -383,7 +388,7 @@ func schema_pkg_apis_appsody_v1beta1_AppsodyApplicationSpec(ref common.Reference
 					},
 					"route": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyRoute"),
+							Ref: ref("./pkg/apis/appsody/v1beta1.AppsodyRoute"),
 						},
 					},
 				},
@@ -391,7 +396,7 @@ func schema_pkg_apis_appsody_v1beta1_AppsodyApplicationSpec(ref common.Reference
 			},
 		},
 		Dependencies: []string{
-			"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationAutoScaling", "github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationMonitoring", "github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationService", "github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyApplicationStorage", "github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.AppsodyRoute", "k8s.io/api/core/v1.Container", "k8s.io/api/core/v1.EnvFromSource", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.Probe", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
+			"./pkg/apis/appsody/v1beta1.AppsodyApplicationAutoScaling", "./pkg/apis/appsody/v1beta1.AppsodyApplicationMonitoring", "./pkg/apis/appsody/v1beta1.AppsodyApplicationService", "./pkg/apis/appsody/v1beta1.AppsodyApplicationStorage", "./pkg/apis/appsody/v1beta1.AppsodyRoute", "k8s.io/api/core/v1.Container", "k8s.io/api/core/v1.EnvFromSource", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.Probe", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 
@@ -413,7 +418,7 @@ func schema_pkg_apis_appsody_v1beta1_AppsodyApplicationStatus(ref common.Referen
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.StatusCondition"),
+										Ref: ref("./pkg/apis/appsody/v1beta1.StatusCondition"),
 									},
 								},
 							},
@@ -450,7 +455,7 @@ func schema_pkg_apis_appsody_v1beta1_AppsodyApplicationStatus(ref common.Referen
 			},
 		},
 		Dependencies: []string{
-			"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.StatusCondition"},
+			"./pkg/apis/appsody/v1beta1.StatusCondition"},
 	}
 }
 
@@ -489,7 +494,13 @@ func schema_pkg_apis_appsody_v1beta1_AppsodyRoute(ref common.ReferenceCallback) 
 					},
 					"certificate": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.Certificate"),
+							Ref: ref("./pkg/apis/appsody/v1beta1.Certificate"),
+						},
+					},
+					"certificateSecretRef": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"host": {
@@ -508,7 +519,7 @@ func schema_pkg_apis_appsody_v1beta1_AppsodyRoute(ref common.ReferenceCallback) 
 			},
 		},
 		Dependencies: []string{
-			"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.Certificate"},
+			"./pkg/apis/appsody/v1beta1.Certificate"},
 	}
 }
 
@@ -577,7 +588,7 @@ func schema_pkg_apis_appsody_v1beta1_ServiceBindingProvides(ref common.Reference
 					},
 					"auth": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.ServiceBindingAuth"),
+							Ref: ref("./pkg/apis/appsody/v1beta1.ServiceBindingAuth"),
 						},
 					},
 				},
@@ -585,7 +596,7 @@ func schema_pkg_apis_appsody_v1beta1_ServiceBindingProvides(ref common.Reference
 			},
 		},
 		Dependencies: []string{
-			"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1.ServiceBindingAuth"},
+			"./pkg/apis/appsody/v1beta1.ServiceBindingAuth"},
 	}
 }
 

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -78,6 +78,7 @@ type BaseApplicationService interface {
 	GetProvides() ServiceBindingProvides
 	GetConsumes() []ServiceBindingConsumes
 	GetCertificate() Certificate
+	GetCertificateSecretRef() *string
 }
 
 // BaseApplicationMonitoring represents basic service monitoring configuration
@@ -94,6 +95,7 @@ type BaseApplicationRoute interface {
 	GetAnnotations() map[string]string
 	GetHost() string
 	GetPath() string
+	GetCertificateSecretRef() *string
 }
 
 // ServiceBindingProvides represents a service to be provided

--- a/pkg/utils/reconciler.go
+++ b/pkg/utils/reconciler.go
@@ -530,7 +530,9 @@ func (r *ReconcilerBase) ReconcileCertificate(ba common.BaseApplication) (reconc
 					crt.Spec.RenewBefore = &metav1.Duration{Duration: time.Hour * 24 * 31}
 				}
 				crt.Spec.CommonName = obj.GetName() + "." + obj.GetNamespace() + "." + "svc"
-				crt.Spec.SecretName = obj.GetName() + "-svc-tls"
+				if crt.Spec.SecretName == "" {
+					crt.Spec.SecretName = obj.GetName() + "-svc-tls"
+				}
 				if len(crt.Spec.DNSNames) == 0 {
 					crt.Spec.DNSNames = append(crt.Spec.DNSNames, crt.Spec.CommonName)
 				}
@@ -580,7 +582,9 @@ func (r *ReconcilerBase) ReconcileCertificate(ba common.BaseApplication) (reconc
 				if crt.Spec.RenewBefore == nil {
 					crt.Spec.RenewBefore = &metav1.Duration{Duration: time.Hour * 24 * 31}
 				}
-				crt.Spec.SecretName = obj.GetName() + "-route-tls"
+				if crt.Spec.SecretName == "" {
+					crt.Spec.SecretName = obj.GetName() + "-route-tls"
+				}
 				// use routes host if no DNS information provided on certificate
 				if crt.Spec.CommonName == "" {
 					crt.Spec.CommonName = ba.GetRoute().GetHost()
@@ -638,9 +642,16 @@ func (r *ReconcilerBase) IsOpenShift() bool {
 func (r *ReconcilerBase) GetRouteTLSValues(ba common.BaseApplication) (key string, cert string, ca string, destCa string, err error) {
 	key, cert, ca, destCa = "", "", "", ""
 	mObj := ba.(metav1.Object)
-	if ba.GetService() != nil && ba.GetService().GetCertificate() != nil {
+	if ba.GetService() != nil && (ba.GetService().GetCertificate() != nil || ba.GetService().GetCertificateSecretRef() != nil) {
 		tlsSecret := &corev1.Secret{}
-		err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: mObj.GetName() + "-svc-tls", Namespace: mObj.GetNamespace()}, tlsSecret)
+		secretName := mObj.GetName() + "-svc-tls"
+		if ba.GetService().GetCertificate() != nil && ba.GetService().GetCertificate().GetSpec().SecretName != "" {
+			secretName = ba.GetService().GetCertificate().GetSpec().SecretName
+		}
+		if ba.GetService().GetCertificateSecretRef() != nil {
+			secretName = *ba.GetService().GetCertificateSecretRef()
+		}
+		err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: mObj.GetNamespace()}, tlsSecret)
 		if err != nil {
 			r.ManageError(err, common.StatusConditionTypeReconciled, ba)
 			return "", "", "", "", err
@@ -650,9 +661,16 @@ func (r *ReconcilerBase) GetRouteTLSValues(ba common.BaseApplication) (key strin
 			destCa = string(caCrt)
 		}
 	}
-	if ba.GetRoute() != nil && ba.GetRoute().GetCertificate() != nil {
+	if ba.GetRoute() != nil && (ba.GetRoute().GetCertificate() != nil || ba.GetRoute().GetCertificateSecretRef() != nil) {
 		tlsSecret := &corev1.Secret{}
-		err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: mObj.GetName() + "-route-tls", Namespace: mObj.GetNamespace()}, tlsSecret)
+		secretName := mObj.GetName() + "-route-tls"
+		if ba.GetRoute().GetCertificate() != nil && ba.GetRoute().GetCertificate().GetSpec().SecretName != "" {
+			secretName = ba.GetRoute().GetCertificate().GetSpec().SecretName
+		}
+		if ba.GetRoute().GetCertificateSecretRef() != nil {
+			secretName = *ba.GetRoute().GetCertificateSecretRef()
+		}
+		err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: mObj.GetNamespace()}, tlsSecret)
 		if err != nil {
 			r.ManageError(err, common.StatusConditionTypeReconciled, ba)
 			return "", "", "", "", err
@@ -668,6 +686,10 @@ func (r *ReconcilerBase) GetRouteTLSValues(ba common.BaseApplication) (key strin
 		v, ok = tlsSecret.Data["tls.key"]
 		if ok {
 			key = string(v)
+		}
+		v, ok = tlsSecret.Data["destCA.crt"]
+		if ok {
+			destCa = string(v)
 		}
 	}
 	return key, cert, ca, destCa, nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -242,13 +242,20 @@ func CustomizePodSpec(pts *corev1.PodTemplateSpec, ba common.BaseApplication) {
 	pts.Spec.Containers[0].VolumeMounts = ba.GetVolumeMounts()
 	pts.Spec.Volumes = ba.GetVolumes()
 
-	if ba.GetService().GetCertificate() != nil {
+	if ba.GetService().GetCertificate() != nil || ba.GetService().GetCertificateSecretRef() != nil {
+		secretName := obj.GetName() + "-svc-tls"
+		if ba.GetService().GetCertificate() != nil && ba.GetService().GetCertificate().GetSpec().SecretName != "" {
+			secretName = ba.GetService().GetCertificate().GetSpec().SecretName
+		}
+		if ba.GetService().GetCertificateSecretRef() != nil {
+			secretName = *ba.GetService().GetCertificateSecretRef()
+		}
 		pts.Spec.Containers[0].Env = append(pts.Spec.Containers[0].Env, corev1.EnvVar{Name: "TLS_DIR", Value: "/etc/x509/certs"})
 		pts.Spec.Volumes = append(pts.Spec.Volumes, corev1.Volume{
 			Name: "svc-certificate",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: obj.GetName() + "-svc-tls",
+					SecretName: secretName,
 				},
 			},
 		})


### PR DESCRIPTION
Adds `certificateSecretRef` field under Service and Route to enable manually providing existing TLS certificates 