### PR TITLE
Add OpenShift recommended labels & annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Changed the default labels and annotations to more closely align with the
+  generic operator and OpenShift guidelines ([#233](https://github.com/appsody/appsody-operator/issues/233))
 - Changed the label corresponding to `metadata.name` to `app.kubernetes.io/instance` and made former label `app.kubernetes.io/name` user configurable. ([#179](https://github.com/appsody/appsody-operator/issues/179))
 
 ## [0.2.2]

--- a/pkg/apis/appsody/v1beta1/appsodyapplication_types.go
+++ b/pkg/apis/appsody/v1beta1/appsodyapplication_types.go
@@ -818,6 +818,8 @@ func (cr *AppsodyApplication) GetLabels() map[string]string {
 		"app.kubernetes.io/instance":   cr.Name,
 		"app.kubernetes.io/name":       cr.Name,
 		"app.kubernetes.io/managed-by": "appsody-operator",
+		"app.kubernetes.io/part-of": cr.Name,
+		"app.kubernetes.io/component": "backend",
 	}
 
 	if cr.Spec.Stack != "" {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -742,6 +742,18 @@ func GetConnectToAnnotation(ba common.BaseApplication) map[string]string {
 	return anno
 }
 
+func GetOpenShiftAnnotations(ba common.BaseApplication) map[string]string {
+	annos := map[string]string{}
+
+	for key, val := range ba.GetLabels() {
+		if key == "image.opencontainer.org/source" {
+			annos["app.openshift.io/vcs-ref"] = val
+		}
+	}
+
+	return MergeMaps(annos, GetConnectToAnnotation(ba))
+}
+
 // IsClusterWide returns true if watchNamespaces is set to [""]
 func IsClusterWide(watchNamespaces []string) bool {
 	return len(watchNamespaces) == 1 && watchNamespaces[0] == ""

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -746,7 +746,7 @@ func GetOpenShiftAnnotations(ba common.BaseApplication) map[string]string {
 	annos := map[string]string{}
 
 	for key, val := range ba.GetLabels() {
-		if key == "image.opencontainer.org/source" {
+		if key == "image.opencontainers.org/source" {
 			annos["app.openshift.io/vcs-ref"] = val
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it?**:
- Adds OpenShift specific annotations, including `connects-to` when defined, to **all** relevant resources as per tips section in the links provided in connected issue.
- Adds the labels documented and included in the generic operator [here](https://github.com/application-stacks/runtime-component-operator/blob/master/doc/user-guide.md#labels)
- Brings default annotations to the following, when the applicable information is set: `app.openshift.io/connects-to` (service binding) and `app.openshift.io/vcs-uri`(new) .

Other annotations do not seem intuitive to infer currently, unless I'm missing some labels set by the appsody CLI that we can utilize.

The operator should now set every label referenced in the issue's [link](https://github.com/gorkem/app-labels/blob/master/labels-annotation-for-openshift.adoc), excluding the `runtime` and `runtime-version` labels. We could infer this from the stack at times, but not all stacks will necessarily have an obvious underlying runtime outside of our defaults.

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [x] User guide
- [x] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #175 
