### PR TITLE
Change monitoring label

### DIFF
--- a/pkg/controller/appsodyapplication/appsodyapplication_controller.go
+++ b/pkg/controller/appsodyapplication/appsodyapplication_controller.go
@@ -10,8 +10,8 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 
 	oputils "github.com/application-stacks/runtime-component-operator/pkg/utils"
-	autils "github.com/appsody/appsody-operator/pkg/utils"
 	appsodyv1beta1 "github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1"
+	autils "github.com/appsody/appsody-operator/pkg/utils"
 	prometheusv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	certmngrv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -585,10 +585,10 @@ func (r *ReconcileAppsodyApplication) Reconcile(request reconcile.Request) (reco
 		svc.Annotations = oputils.MergeMaps(svc.Annotations, instance.Spec.Service.Annotations)
 
 		if instance.Spec.Monitoring != nil {
-			svc.Labels["app."+ba.GetGroupName()+"/monitor"] = "true"
+			svc.Labels["monitor."+ba.GetGroupName()+"/enabled"] = "true"
 		} else {
-			if _, ok := svc.Labels["app."+ba.GetGroupName()+"/monitor"]; ok {
-				delete(svc.Labels, "app."+ba.GetGroupName()+"/monitor")
+			if _, ok := svc.Labels["monitor."+ba.GetGroupName()+"/enabled"]; ok {
+				delete(svc.Labels, "monitor."+ba.GetGroupName()+"/enabled")
 			}
 		}
 		return nil


### PR DESCRIPTION
Signed-off-by: leochr <leojc@ca.ibm.com>

**What this PR does / why we need it?**:

- Change monitoring label from `app.appsody.dev/monitor` to `monitor.appsody.dev/enabled`

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #170 
