### PR TITLE
Fix OpenShift annotation for version control uri

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -6,12 +6,13 @@ import (
 	oputils "github.com/application-stacks/runtime-component-operator/pkg/utils"
 )
 
+// GetOpenShiftAnnotations add any additional annotations that are provided by the CLI tool
 func GetOpenShiftAnnotations(ba common.BaseComponent) map[string]string {
 	annos := map[string]string{}
 
 	for key, val := range ba.GetLabels() {
 		if key == "image.opencontainers.org/source" {
-			annos["app.openshift.io/vcs-ref"] = val
+			annos["app.openshift.io/vcs-uri"] = val
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Updates the method for getting potential version control uri from labels set by the appsody CLI to use the right annotation