### PR TITLE
Fix issue with manifest build target

### DIFF
--- a/scripts/build-releases.sh
+++ b/scripts/build-releases.sh
@@ -66,6 +66,9 @@ main() {
     echo "****** Pushing release: ${dockerTag}"
     push_release "${dockerTag}"
   done <<< "${tags}"
+
+  echo "****** Complete"
+  git checkout -q master
 }
 
 build_release() {


### PR DESCRIPTION
**What this PR does / why we need it?**:

-  Checkout the master branch after building and pushing other release commits, as the build manifest make target doesn't exist in previous commits. This wasn't a problem in Runtime Operator as these scripts were present from first release onward.
