### PR TITLE
Adding air gap CSV

### DIFF
--- a/deploy/olm-catalog/appsody-operator-certified/appsody-operator.v0.6.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/appsody-operator-certified/appsody-operator.v0.6.1.clusterserviceversion.yaml
@@ -1,0 +1,319 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"appsody.dev/v1beta1","kind":"AppsodyApplication","metadata":{"name":"example-appsodyapplication"},"spec":{"applicationImage":"registry.connect.redhat.com/ibm/open-liberty-samples:springPetClinic","stack":"java-openliberty"}}]'
+    capabilities: Seamless Upgrades
+    categories: Application Runtime
+    certified: 'true'
+    containerImage: registry.connect.redhat.com/ibm/appsody-application-operator@sha256:870318a851e513b536cfaa1cfc8bfd79c55990663cb972dd27c92bd0e06b9fba
+    createdAt: 2020-06-26 09:00:00
+    description: Deploys Appsody based applications
+    repository: https://github.com/appsody/appsody-operator
+    support: Appsody
+  name: appsody-operator.v0.6.1
+spec:
+  customresourcedefinitions:
+    owned:
+    - description: Configuration for the deployment of an Appsody application 
+      displayName: Appsody Application
+      kind: AppsodyApplication
+      name: appsodyapplications.appsody.dev
+      resources:
+      - kind: Deployment
+        name: ''
+      - kind: StatefulSet
+        name: ''
+      - kind: Service
+        name: ''
+      - kind: Route
+        name: ''
+      - kind: HorizontalPodAutoscaler
+        name: ''
+      specDescriptors:
+      - description: application stack
+        displayName: Stack
+        path: stack
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:label
+      - description: application image to be installed
+        displayName: Application Image
+        path: applicationImage
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: version of the application
+        displayName: Application Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: image pull policy for container image
+        displayName: Pull Policy
+        path: pullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+      - description: number of pods to create
+        displayName: Replicas
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: automatically create HTTP Route
+        displayName: Expose
+        path: expose
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: resource requirements for cpu and memory
+        displayName: Resource Requirements
+        path: resourceConstraints
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: port to use for kubernetes service
+        displayName: Service Port
+        path: service.port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: type to use for kubernetes service
+        displayName: Service Type
+        path: service.type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: horizontal pod autoscaling
+        displayName: Autoscaling
+        path: autoscaling
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:label
+      statusDescriptors:
+      - description: status conditions
+        displayName: Status conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta1
+  description: 'The Appsody Operator allows easy deployment of applications developed
+    with [Appsody](https://appsody.dev) to Kubernetes environments. The operator provides
+    the following key features:
+
+
+    #### Routing
+
+
+    Expose your application to external users via a single toggle to create a Route on OpenShift or an Ingress on other Kubernetes environments.
+    Advanced configuration, such as TLS settings, are also easily enabled.  Expiring Route certificates are re-issued.
+
+
+    #### High Availability
+
+
+    Run multiple instances of your application for high availability. Either specify
+    a static number of replicas or easily configure auto scaling to create (and delete)
+    instances based on resource consumption.
+
+
+    #### Persistence
+
+
+    Enable persistence for your application by specifying storage requirements.
+
+
+    #### Service Binding
+
+
+    Easily bind to available services in your cluster.
+
+
+    #### Knative
+
+
+    Deploy your serverless application on [Knative](https://knative.dev) using a single
+    toggle.
+
+
+    #### Integration with OpenShift''s Certificate Manager
+
+    The Appsody Operator takes advantage of the [cert-manager tool](https://cert-manager.io/), if it is installed on the cluster. This allows the operator to
+    automatically provision TLS certificates for pods as well as routes.
+
+
+    #### Kubernetes Application Navigator (kAppNav)
+
+
+    Automatically configures the Kubernetes resources for integration with [kAppNav](https://kappnav.io/).
+
+
+    See our [**documentation**](https://github.com/appsody/appsody-operator/tree/master/doc/)
+    for more information.
+
+    '
+  displayName: Appsody Operator
+  icon:
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1Ni43MSA1MC43NSI+PGRlZnM+PHN0eWxlPi5he2lzb2xhdGlvbjppc29sYXRlO30uYntvcGFjaXR5OjAuODt9LmIsLmV7bWl4LWJsZW5kLW1vZGU6bXVsdGlwbHk7fS5je2ZpbGw6I2VkOGUwMDt9LmR7ZmlsbDojYzQzMDJmO30uZXtmaWxsOiNhZjFmNjQ7b3BhY2l0eTowLjg1O308L3N0eWxlPjwvZGVmcz48dGl0bGU+QXNzZXQgMjwvdGl0bGU+PGcgY2xhc3M9ImEiPjxnIGNsYXNzPSJiIj48cGF0aCBjbGFzcz0iYyIgZD0iTTI1Ljg4LjI4Yy0yLjUtLjgxLTUuNTguMTQtOC42MywzLjA2TDMuODcsMTYuMTdDLTIuMjIsMjItMSwyOC44MSw2LjYyLDMxLjI3bDE2LjcsNS40MWM3LjYxLDIuNDYsMTIuNi0yLjMyLDExLjA4LTEwLjYyTDMxLjA4LDcuODJjLS43Ni00LjE1LTIuNjktNi43My01LjItNy41NFoiLz48L2c+PGcgY2xhc3M9ImIiPjxwYXRoIGNsYXNzPSJkIiBkPSJNMzcuOTQsMy4xNEExNS43MywxNS43MywwLDAsMCwzMi41NSw0LjZMMTQuNjYsMTIuNzNjLTQuNTcsMi4wNy03LjMxLDUuMjYtNy43Miw5LS4zOSwzLjUyLDEuNDIsNyw1LjA4LDkuNzRsMTUsMTEuMzFhMTIuMjgsMTIuMjgsMCwwLDAsOC4wNiwyLjhjNC43Ny0uMzEsOC4yOS00LjM1LDkuMi0xMC41M2wyLjg0LTE5LjQ0QzQ4LjEyLDksNDUuNTEsNiw0My44Nyw0Ljc1YTguNzksOC43OSwwLDAsMC01LjkzLTEuNjFaIi8+PC9nPjxwYXRoIGNsYXNzPSJlIiBkPSJNMzMuOCw1MC43MWMtMi45My0uMzMtNS41Ny0yLjM5LTcuNDktNS44OEwxNywyNy44Yy0yLjExLTMuODMtMi4zLTcuNDYtLjU0LTEwLjIyczUuMjEtNC4yNiw5Ljc2LTQuMjhsMjAuMjctLjA3YzQuNTYsMCw3LjkxLDEuNSw5LjQyLDQuMjVzMSw2LjM5LTEuNDUsMTAuMjNMNDMuNDksNDQuOGMtMi40NCwzLjgzLTUuNTgsNS45NC04LjgzLDZBNi4xMiw2LjEyLDAsMCwxLDMzLjgsNTAuNzFaIi8+PC9nPjwvc3ZnPg==
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - namespaces
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resourceNames:
+          - appsody-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - appsody.dev
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          verbs:
+          - '*'
+        - apiGroups:
+          - serving.knative.dev
+          resources:
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificates
+          verbs:
+          - '*'
+        - apiGroups:
+          - app.k8s.io
+          resources:
+          - applications
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - servicebindingrequests
+          verbs:
+          - '*'
+        - apiGroups:
+          - networking.k8s.io
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        serviceAccountName: appsody-operator
+      deployments:
+      - name: appsody-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: appsody-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: appsody-operator
+            spec:
+              containers:
+              - command:
+                - appsody-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: appsody-operator
+                image: registry.connect.redhat.com/ibm/appsody-application-operator@sha256:870318a851e513b536cfaa1cfc8bfd79c55990663cb972dd27c92bd0e06b9fba
+                imagePullPolicy: Always
+                name: appsody-operator
+                resources: {}
+              serviceAccountName: appsody-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - Appsody
+  - Application
+  - Node
+  - Swift
+  - MicroProfile
+  - Spring
+  - Java
+  - Runtime
+  - Kabanero
+  - Open Source
+  links:
+  - name: Documentation
+    url: https://github.com/appsody/appsody-operator/tree/master/doc/
+  - name: Appsody
+    url: https://appsody.dev
+  maintainers:
+  - email: dzmitry@ca.ibm.com
+    name: Artur Dzmitryieu
+  - email: navidst@ca.ibm.com
+    name: Navid Shakibapour Tabrizi
+  - email: leojc@ca.ibm.com
+    name: Leo Christy Jesuraj
+  - email: arthurdm@ca.ibm.com
+    name: Arthur De Magalhaes
+  maturity: beta
+  provider:
+    name: Appsody
+  replaces: appsody-operator.v0.6.0
+  version: 0.6.1


### PR DESCRIPTION
Adding a 0.6.1 CSV where the controller image is referenced by its digest instead of the tag.  This is required to support the air gap scenario.